### PR TITLE
Build local npm package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,22 +136,12 @@ The npm package version comes from `neems-api/Cargo.toml`. When changing types:
 
 ### Local development workflow
 
-When developing backend + frontend simultaneously, the published npm package will be out of date. Two approaches:
+When developing backend + frontend simultaneously, the published npm package will be out of date. The Docker dev environment handles this automatically:
 
-**Direct generation (current behavior):** The `docker-entrypoint.sh` runs `cargo watch` to generate types directly into `../../react/src/types/generated`. If the frontend imports from this local path, no changes are needed.
-
-**npm link (when frontend imports from `@newtown-energy/types`):**
-```bash
-# In neems-core container: generate and build the package
-cd /Users/slifty/Maestral/Code/open-tech-strategies/newtown/devenv && docker compose exec neems-api bash -c "NEEMS_TS_OUTPUT_DIR=npm-build/src cargo test --features test-staging generate_typescript_types"
-# Then on the host, generate scaffolding and build:
-cd /Users/slifty/Maestral/Code/open-tech-strategies/newtown/neems-core/npm-build
-# (create package.json, tsconfig.json, barrel index.ts as the CI workflow does)
-npm install && npx tsc && npm link
-
-# In neems-react:
-npm link @newtown-energy/types
-```
+- On startup, `docker-entrypoint.sh` generates TypeScript types and builds a local `@newtown-energy/types` package in `local-types/` (at the project root)
+- `cargo watch` regenerates types whenever Rust source files change, then rebuilds the local package via `bin/build-local-types-package.sh`
+- The neems-react container uses `bun link` to symlink `node_modules/@newtown-energy/types` to the shared `local-types/` directory, so imports resolve to the local build automatically
+- No manual `npm link` or other steps are needed
 
 ## Code Style
 

--- a/bin/build-local-types-package.sh
+++ b/bin/build-local-types-package.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Build a local @newtown-energy/types package from generated .ts files.
+# Called after each type generation cycle so neems-react can resolve
+# the package via a Docker bind mount.
+#
+# Usage: build-local-types-package.sh <output-dir>
+
+set -e
+
+OUTPUT_DIR="${1:?Usage: build-local-types-package.sh <output-dir>}"
+
+# Check if any .ts files exist (excluding index.ts which we create)
+shopt -s nullglob
+ts_files=("$OUTPUT_DIR"/*.ts)
+shopt -u nullglob
+
+# Filter out index.ts from the list
+source_files=()
+for f in "${ts_files[@]}"; do
+  if [ "$(basename "$f")" != "index.ts" ]; then
+    source_files+=("$f")
+  fi
+done
+
+if [ ${#source_files[@]} -eq 0 ]; then
+  echo "No .ts files found in $OUTPUT_DIR — skipping local types package build"
+  exit 0
+fi
+
+# Generate barrel index.ts
+echo "// Auto-generated barrel file — do not edit" > "$OUTPUT_DIR/index.ts"
+for f in "${source_files[@]}"; do
+  basename="$(basename "$f" .ts)"
+  echo "export * from './${basename}';" >> "$OUTPUT_DIR/index.ts"
+done
+
+# Generate package.json
+cat > "$OUTPUT_DIR/package.json" << 'PKGJSON'
+{
+  "name": "@newtown-energy/types",
+  "version": "0.0.0-local",
+  "description": "Locally-built types from neems-core (auto-generated)",
+  "types": "./index.ts",
+  "exports": {
+    ".": "./index.ts"
+  }
+}
+PKGJSON
+
+echo "Local types package built in $OUTPUT_DIR (${#source_files[@]} type files)"

--- a/neems-api/docker-entrypoint.sh
+++ b/neems-api/docker-entrypoint.sh
@@ -18,12 +18,17 @@ echo "Setting up demo data..."
 export NEEMS_ADMIN_BIN=/usr/src/app/target/debug/neems-admin
 /usr/src/app/bin/setup-demo-data || echo "Demo data setup failed or already complete"
 
+# Generate TypeScript types synchronously on startup (before neems-react starts)
+echo "Generating TypeScript types (initial)..."
+cargo test --features test-staging generate_typescript_types --quiet || true
+/usr/src/app/bin/build-local-types-package.sh "$NEEMS_TS_OUTPUT_DIR"
+
 # Run TypeScript generation in the background, watching for Rust file changes
 cargo watch \
   --features test-staging \
   -w neems-api/src \
   -w neems-data/src \
-  -s 'cargo test --features test-staging generate_typescript_types --quiet' &
+  -s 'cargo test --features test-staging generate_typescript_types --quiet && /usr/src/app/bin/build-local-types-package.sh "${NEEMS_TS_OUTPUT_DIR}"' &
 
 # Run the main API server with live reload
 exec cargo watch \


### PR DESCRIPTION
Now that we publish the type definitions to NPM we want to expose a local version too, for local development.  This means that other projects that rely on the npm package can use "unreleased" types.