### PR TITLE
Migrate to github packages

### DIFF
--- a/.github/workflows/publish-types.yml
+++ b/.github/workflows/publish-types.yml
@@ -31,7 +31,10 @@ jobs:
       - name: Check published version
         id: check
         run: |
-          PUBLISHED=$(npm view @newtown-energy/types version 2>/dev/null || echo "0.0.0")
+          # Query GitHub Packages API for published versions
+          # Handle cases: package doesn't exist (error object), no versions (empty array), or has versions (array)
+          PUBLISHED=$(curl -s "https://api.github.com/orgs/Newtown-Energy/packages/npm/@newtown-energy%2Ftypes/versions" \
+            -H "Accept: application/vnd.github+json" | jq -r 'if type == "array" and length > 0 then .[0].name else "0.0.0" end')
           if [ "$VERSION" = "$PUBLISHED" ]; then
             echo "new_version=false" >> "$GITHUB_OUTPUT"
             echo "Version $VERSION already published"
@@ -48,7 +51,8 @@ jobs:
     if: needs.check-version.outputs.new_version == 'true'
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -70,7 +74,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: ".node-version"
-          registry-url: "https://registry.npmjs.org"
+          registry-url: "https://npm.pkg.github.com"
 
       - name: Create npm-build directory
         run: mkdir -p npm-build/src
@@ -107,4 +111,6 @@ jobs:
 
       - name: Publish${{ github.ref != 'refs/heads/main' && ' (dry run)' || '' }}
         working-directory: npm-build
-        run: npm publish --access public ${{ github.ref == 'refs/heads/main' && '--provenance' || '--dry-run' }}
+        run: npm publish --access public ${{ github.ref != 'refs/heads/main' && '--dry-run' || '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,17 +114,17 @@ The project uses GitHub Actions for CI/CD:
 
 ## npm Types Package (`@newtown-energy/types`)
 
-TypeScript types are auto-generated from Rust structs via `ts-rs`. On merge to `main`, the `.github/workflows/publish-types.yml` workflow publishes them to npmjs.com as `@newtown-energy/types`.
+TypeScript types are auto-generated from Rust structs via `ts-rs`. On merge to `main`, the `.github/workflows/publish-types.yml` workflow publishes them to GitHub Packages (`npm.pkg.github.com`) as `@newtown-energy/types`.
 
 ### How it works
 
-The workflow has two jobs: **build** (runs on all PRs and main) and **publish** (runs only on main when the version has changed). Template files live in `npm/`:
+The workflow has two jobs: **check-version** (determines if a new version needs publishing) and **build-and-publish** (runs only when the version has changed). Template files live in `npm/`:
 - `npm/package.template.json` — package.json template (version placeholder replaced at build time)
 - `npm/tsconfig.json` — TypeScript compiler config
 
 The build job generates types via `cargo test`, scaffolds the package from templates, generates a barrel `index.ts`, and compiles with `tsc`. On PRs this serves as a dry-run to catch build failures before merge.
 
-Publishing uses npm's OIDC trusted publishing (no tokens or secrets needed). The trusted publisher is configured on npmjs.com to authorize this workflow.
+Publishing uses the `GITHUB_TOKEN` which is automatically available in GitHub Actions. The package is published as a **public package** to GitHub Packages, so no authentication is required to install it.
 
 ### Version bumping
 

--- a/npm/package.template.json
+++ b/npm/package.template.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/Newtown-Energy/neems-core.git"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "devDependencies": {
     "typescript": "^5.0.0"
   }


### PR DESCRIPTION
The initial move to package types and publish was built on npm; we want to use github's registry instead (since we're already in that ecosystem).

Issue #40 Move the type package to github releases