### PR TITLE
Add duration_seconds and target_soc_percent to schedule commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "neems-api"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "argon2",
  "built",

--- a/neems-api/Cargo.toml
+++ b/neems-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neems-api"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 default-run = "neems-api"
 

--- a/neems-api/migrations/2026-03-15-120000_add_duration_and_target_soc/down.sql
+++ b/neems-api/migrations/2026-03-15-120000_add_duration_and_target_soc/down.sql
@@ -1,0 +1,54 @@
+-- Revert: Remove duration_seconds and target_soc_percent from schedule_commands
+
+-- Create old table structure
+CREATE TABLE schedule_commands_old (
+    id INTEGER PRIMARY KEY NOT NULL,
+    site_id INTEGER NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('charge', 'discharge', 'trickle_charge')),
+    parameters TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT 1,
+    FOREIGN KEY(site_id) REFERENCES sites(id) ON DELETE CASCADE
+);
+
+-- Copy data back (dropping new columns)
+INSERT INTO schedule_commands_old (id, site_id, type, parameters, is_active)
+SELECT id, site_id, type, parameters, is_active
+FROM schedule_commands;
+
+-- Drop existing triggers
+DROP TRIGGER IF EXISTS schedule_commands_insert_log;
+DROP TRIGGER IF EXISTS schedule_commands_update_log;
+DROP TRIGGER IF EXISTS schedule_commands_delete_log;
+
+-- Drop new table and rename old table
+DROP TABLE schedule_commands;
+ALTER TABLE schedule_commands_old RENAME TO schedule_commands;
+
+-- Recreate indexes
+CREATE INDEX idx_schedule_commands_site ON schedule_commands(site_id);
+CREATE INDEX idx_schedule_commands_site_active ON schedule_commands(site_id, is_active);
+
+-- Recreate triggers
+CREATE TRIGGER schedule_commands_insert_log
+AFTER INSERT ON schedule_commands
+FOR EACH ROW
+BEGIN
+    INSERT INTO entity_activity (table_name, entity_id, operation_type, timestamp)
+    VALUES ('schedule_commands', NEW.id, 'create', CURRENT_TIMESTAMP);
+END;
+
+CREATE TRIGGER schedule_commands_update_log
+AFTER UPDATE ON schedule_commands
+FOR EACH ROW
+BEGIN
+    INSERT INTO entity_activity (table_name, entity_id, operation_type, timestamp)
+    VALUES ('schedule_commands', NEW.id, 'update', CURRENT_TIMESTAMP);
+END;
+
+CREATE TRIGGER schedule_commands_delete_log
+AFTER DELETE ON schedule_commands
+FOR EACH ROW
+BEGIN
+    INSERT INTO entity_activity (table_name, entity_id, operation_type, timestamp)
+    VALUES ('schedule_commands', OLD.id, 'delete', CURRENT_TIMESTAMP);
+END;

--- a/neems-api/migrations/2026-03-15-120000_add_duration_and_target_soc/up.sql
+++ b/neems-api/migrations/2026-03-15-120000_add_duration_and_target_soc/up.sql
@@ -1,0 +1,57 @@
+-- Add duration_seconds and target_soc_percent to schedule_commands
+-- SQLite requires table recreation to add columns with CHECK constraints
+
+-- Create new table with additional columns
+CREATE TABLE schedule_commands_new (
+    id INTEGER PRIMARY KEY NOT NULL,
+    site_id INTEGER NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('charge', 'discharge', 'trickle_charge')),
+    parameters TEXT,
+    duration_seconds INTEGER CHECK (duration_seconds IS NULL OR duration_seconds > 0),
+    target_soc_percent INTEGER CHECK (target_soc_percent IS NULL OR (target_soc_percent >= 0 AND target_soc_percent <= 100)),
+    is_active BOOLEAN NOT NULL DEFAULT 1,
+    FOREIGN KEY(site_id) REFERENCES sites(id) ON DELETE CASCADE
+);
+
+-- Copy existing data (new columns get NULL by default)
+INSERT INTO schedule_commands_new (id, site_id, type, parameters, duration_seconds, target_soc_percent, is_active)
+SELECT id, site_id, type, parameters, NULL, NULL, is_active
+FROM schedule_commands;
+
+-- Drop existing triggers before dropping table
+DROP TRIGGER IF EXISTS schedule_commands_insert_log;
+DROP TRIGGER IF EXISTS schedule_commands_update_log;
+DROP TRIGGER IF EXISTS schedule_commands_delete_log;
+
+-- Drop old table and rename new table
+DROP TABLE schedule_commands;
+ALTER TABLE schedule_commands_new RENAME TO schedule_commands;
+
+-- Recreate indexes
+CREATE INDEX idx_schedule_commands_site ON schedule_commands(site_id);
+CREATE INDEX idx_schedule_commands_site_active ON schedule_commands(site_id, is_active);
+
+-- Recreate triggers for entity activity tracking
+CREATE TRIGGER schedule_commands_insert_log
+AFTER INSERT ON schedule_commands
+FOR EACH ROW
+BEGIN
+    INSERT INTO entity_activity (table_name, entity_id, operation_type, timestamp)
+    VALUES ('schedule_commands', NEW.id, 'create', CURRENT_TIMESTAMP);
+END;
+
+CREATE TRIGGER schedule_commands_update_log
+AFTER UPDATE ON schedule_commands
+FOR EACH ROW
+BEGIN
+    INSERT INTO entity_activity (table_name, entity_id, operation_type, timestamp)
+    VALUES ('schedule_commands', NEW.id, 'update', CURRENT_TIMESTAMP);
+END;
+
+CREATE TRIGGER schedule_commands_delete_log
+AFTER DELETE ON schedule_commands
+FOR EACH ROW
+BEGIN
+    INSERT INTO entity_activity (table_name, entity_id, operation_type, timestamp)
+    VALUES ('schedule_commands', OLD.id, 'delete', CURRENT_TIMESTAMP);
+END;

--- a/neems-api/src/models/schedule_library.rs
+++ b/neems-api/src/models/schedule_library.rs
@@ -35,6 +35,8 @@ pub struct ScheduleCommand {
     #[serde(rename = "type")]
     pub type_: String,
     pub parameters: Option<String>,
+    pub duration_seconds: Option<i32>,
+    pub target_soc_percent: Option<i32>,
     pub is_active: bool,
 }
 
@@ -45,6 +47,8 @@ pub struct NewScheduleCommand {
     pub site_id: i32,
     pub type_: String,
     pub parameters: Option<String>,
+    pub duration_seconds: Option<i32>,
+    pub target_soc_percent: Option<i32>,
     pub is_active: bool,
 }
 
@@ -69,8 +73,8 @@ pub struct ScheduleTemplate {
     pub name: String,
     pub description: Option<String>,
     pub is_active: bool,
-    pub created_at: chrono::NaiveDateTime,
     pub is_default: bool,
+    pub created_at: chrono::NaiveDateTime,
 }
 
 /// Insertable struct for creating new schedule templates
@@ -129,6 +133,8 @@ pub struct ScheduleCommandDto {
     pub id: i32,
     pub execution_offset_seconds: i32,
     pub command_type: CommandType,
+    pub duration_seconds: Option<i32>,
+    pub target_soc_percent: Option<i32>,
 }
 
 /// A schedule library item (template with embedded commands)
@@ -159,6 +165,8 @@ pub struct CreateLibraryItemRequest {
 pub struct CreateCommandRequest {
     pub execution_offset_seconds: i32,
     pub command_type: CommandType,
+    pub duration_seconds: Option<i32>,
+    pub target_soc_percent: Option<i32>,
 }
 
 /// Request to update a library item

--- a/neems-api/src/orm/schedule_library.rs
+++ b/neems-api/src/orm/schedule_library.rs
@@ -60,11 +60,16 @@ pub fn create_library_item(
         // 4. For each command, create command + entry
         let mut created_commands = Vec::new();
         for cmd_req in request.commands.iter() {
+            // Validate command
+            validate_command(cmd_req)?;
+
             // Insert command
             let new_cmd = NewScheduleCommand {
                 site_id,
                 type_: cmd_req.command_type.as_str().to_string(),
                 parameters: None,
+                duration_seconds: cmd_req.duration_seconds,
+                target_soc_percent: cmd_req.target_soc_percent,
                 is_active: true,
             };
 
@@ -90,6 +95,8 @@ pub fn create_library_item(
                 id: cmd_id,
                 execution_offset_seconds: cmd_req.execution_offset_seconds,
                 command_type: cmd_req.command_type.clone(),
+                duration_seconds: cmd_req.duration_seconds,
+                target_soc_percent: cmd_req.target_soc_percent,
             });
         }
 
@@ -119,23 +126,30 @@ pub fn get_library_item(
     let template = schedule_templates::table.find(item_id).first::<ScheduleTemplate>(conn)?;
 
     // Get entries with commands (JOIN)
-    let entries_with_commands: Vec<(ScheduleTemplateEntry, String)> =
+    let entries_with_commands: Vec<(ScheduleTemplateEntry, String, Option<i32>, Option<i32>)> =
         schedule_template_entries::table
             .inner_join(schedule_commands::table)
             .filter(schedule_template_entries::template_id.eq(item_id))
             .filter(schedule_template_entries::is_active.eq(true))
             .order_by(schedule_template_entries::execution_offset_seconds.asc())
-            .select((ScheduleTemplateEntry::as_select(), schedule_commands::type_))
+            .select((
+                ScheduleTemplateEntry::as_select(),
+                schedule_commands::type_,
+                schedule_commands::duration_seconds,
+                schedule_commands::target_soc_percent,
+            ))
             .load(conn)?;
 
     // Map to ScheduleCommandDto
     let commands: Result<Vec<ScheduleCommandDto>, String> = entries_with_commands
         .into_iter()
-        .map(|(entry, type_str)| {
+        .map(|(entry, type_str, duration_seconds, target_soc_percent)| {
             Ok(ScheduleCommandDto {
                 id: entry.id,
                 execution_offset_seconds: entry.execution_offset_seconds,
                 command_type: CommandType::from_str(&type_str)?,
+                duration_seconds,
+                target_soc_percent,
             })
         })
         .collect();
@@ -221,6 +235,11 @@ pub fn update_library_item(
         if let Some(commands) = request.commands {
             validate_execution_offsets(&commands)?;
 
+            // Validate each command
+            for cmd_req in commands.iter() {
+                validate_command(cmd_req)?;
+            }
+
             // Get existing entries
             let existing_entries: Vec<ScheduleTemplateEntry> = schedule_template_entries::table
                 .filter(schedule_template_entries::template_id.eq(item_id))
@@ -247,6 +266,8 @@ pub fn update_library_item(
                     site_id: current.site_id,
                     type_: cmd_req.command_type.as_str().to_string(),
                     parameters: None,
+                    duration_seconds: cmd_req.duration_seconds,
+                    target_soc_percent: cmd_req.target_soc_percent,
                     is_active: true,
                 };
 
@@ -319,7 +340,7 @@ pub fn clone_library_item(
     // Get original item
     let original = get_library_item(conn, item_id)?;
 
-    // Create new item with same commands
+    // Create new item with same commands (preserving duration and target SOC)
     let create_request = CreateLibraryItemRequest {
         name: new_name,
         description: new_description,
@@ -329,6 +350,8 @@ pub fn clone_library_item(
             .map(|cmd| CreateCommandRequest {
                 execution_offset_seconds: cmd.execution_offset_seconds,
                 command_type: cmd.command_type,
+                duration_seconds: cmd.duration_seconds,
+                target_soc_percent: cmd.target_soc_percent,
             })
             .collect(),
     };
@@ -474,6 +497,33 @@ fn validate_execution_offsets(
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     "Duplicate execution times are not allowed",
+                ),
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates duration_seconds and target_soc_percent for a command
+fn validate_command(cmd: &CreateCommandRequest) -> Result<(), diesel::result::Error> {
+    if let Some(duration) = cmd.duration_seconds {
+        if duration <= 0 {
+            return Err(diesel::result::Error::DeserializationError(Box::new(
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "duration_seconds must be positive",
+                ),
+            )));
+        }
+    }
+
+    if let Some(soc) = cmd.target_soc_percent {
+        if !(0..=100).contains(&soc) {
+            return Err(diesel::result::Error::DeserializationError(Box::new(
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "target_soc_percent must be between 0 and 100",
                 ),
             )));
         }

--- a/neems-api/src/schema.rs
+++ b/neems-api/src/schema.rs
@@ -82,6 +82,8 @@ diesel::table! {
         #[sql_name = "type"]
         type_ -> Text,
         parameters -> Nullable<Text>,
+        duration_seconds -> Nullable<Integer>,
+        target_soc_percent -> Nullable<Integer>,
         is_active -> Bool,
     }
 }
@@ -103,8 +105,8 @@ diesel::table! {
         name -> Text,
         description -> Nullable<Text>,
         is_active -> Bool,
-        created_at -> Timestamp,
         is_default -> Bool,
+        created_at -> Timestamp,
     }
 }
 

--- a/neems-api/tests/schedule_library_api.rs
+++ b/neems-api/tests/schedule_library_api.rs
@@ -434,3 +434,345 @@ async fn test_list_library_items() {
     // Should have at least 4 items (3 created + 1 auto-created default)
     assert!(items.len() >= 4);
 }
+
+// ============================================================================
+// Tests for duration_seconds and target_soc_percent fields
+// ============================================================================
+
+#[rocket::async_test]
+async fn test_create_command_with_duration_and_target_soc() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    let new_item = json!({
+        "name": "Full Command Test",
+        "commands": [
+            {
+                "execution_offset_seconds": 28800,
+                "command_type": "charge",
+                "duration_seconds": 3600,
+                "target_soc_percent": 80
+            }
+        ]
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::Created);
+    let item: ScheduleLibraryItem = response.into_json().await.expect("valid JSON");
+
+    assert_eq!(item.commands.len(), 1);
+    assert_eq!(item.commands[0].duration_seconds, Some(3600));
+    assert_eq!(item.commands[0].target_soc_percent, Some(80));
+}
+
+#[rocket::async_test]
+async fn test_create_command_with_only_duration() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    let new_item = json!({
+        "name": "Duration Only Test",
+        "commands": [
+            {
+                "execution_offset_seconds": 28800,
+                "command_type": "discharge",
+                "duration_seconds": 7200
+            }
+        ]
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::Created);
+    let item: ScheduleLibraryItem = response.into_json().await.expect("valid JSON");
+
+    assert_eq!(item.commands[0].duration_seconds, Some(7200));
+    assert_eq!(item.commands[0].target_soc_percent, None);
+}
+
+#[rocket::async_test]
+async fn test_create_command_with_only_target_soc() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    let new_item = json!({
+        "name": "SOC Only Test",
+        "commands": [
+            {
+                "execution_offset_seconds": 28800,
+                "command_type": "trickle_charge",
+                "target_soc_percent": 100
+            }
+        ]
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::Created);
+    let item: ScheduleLibraryItem = response.into_json().await.expect("valid JSON");
+
+    assert_eq!(item.commands[0].duration_seconds, None);
+    assert_eq!(item.commands[0].target_soc_percent, Some(100));
+}
+
+#[rocket::async_test]
+async fn test_create_command_invalid_duration_zero() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    let new_item = json!({
+        "name": "Invalid Duration Zero",
+        "commands": [
+            {
+                "execution_offset_seconds": 28800,
+                "command_type": "charge",
+                "duration_seconds": 0
+            }
+        ]
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::InternalServerError);
+}
+
+#[rocket::async_test]
+async fn test_create_command_invalid_duration_negative() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    let new_item = json!({
+        "name": "Invalid Duration Negative",
+        "commands": [
+            {
+                "execution_offset_seconds": 28800,
+                "command_type": "charge",
+                "duration_seconds": -100
+            }
+        ]
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::InternalServerError);
+}
+
+#[rocket::async_test]
+async fn test_create_command_invalid_soc_over_100() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    let new_item = json!({
+        "name": "Invalid SOC Over 100",
+        "commands": [
+            {
+                "execution_offset_seconds": 28800,
+                "command_type": "charge",
+                "target_soc_percent": 150
+            }
+        ]
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::InternalServerError);
+}
+
+#[rocket::async_test]
+async fn test_create_command_invalid_soc_negative() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    let new_item = json!({
+        "name": "Invalid SOC Negative",
+        "commands": [
+            {
+                "execution_offset_seconds": 28800,
+                "command_type": "charge",
+                "target_soc_percent": -10
+            }
+        ]
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::InternalServerError);
+}
+
+#[rocket::async_test]
+async fn test_create_command_soc_boundary_values() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    // Test SOC = 0 (valid)
+    let new_item = json!({
+        "name": "SOC Zero Test",
+        "commands": [
+            {
+                "execution_offset_seconds": 28800,
+                "command_type": "discharge",
+                "target_soc_percent": 0
+            }
+        ]
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::Created);
+    let item: ScheduleLibraryItem = response.into_json().await.expect("valid JSON");
+    assert_eq!(item.commands[0].target_soc_percent, Some(0));
+
+    // Test SOC = 100 (valid)
+    let new_item = json!({
+        "name": "SOC Hundred Test",
+        "commands": [
+            {
+                "execution_offset_seconds": 32400,
+                "command_type": "charge",
+                "target_soc_percent": 100
+            }
+        ]
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::Created);
+    let item: ScheduleLibraryItem = response.into_json().await.expect("valid JSON");
+    assert_eq!(item.commands[0].target_soc_percent, Some(100));
+}
+
+#[rocket::async_test]
+async fn test_clone_preserves_duration_and_soc() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    // Create an item with duration and SOC
+    let new_item = json!({
+        "name": "Clone Source With Fields",
+        "commands": [
+            {
+                "execution_offset_seconds": 10800,
+                "command_type": "charge",
+                "duration_seconds": 5400,
+                "target_soc_percent": 90
+            }
+        ]
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+    let created: ScheduleLibraryItem = response.into_json().await.expect("valid JSON");
+
+    // Clone it
+    let clone_request = json!({
+        "name": "Cloned With Fields"
+    });
+
+    let url = format!("/api/1/ScheduleLibraryItems/{}/Clone", created.id);
+    let response = client
+        .post(&url)
+        .cookie(admin_cookie.clone())
+        .json(&clone_request)
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), Status::Created);
+    let cloned: ScheduleLibraryItem = response.into_json().await.expect("valid JSON");
+
+    // Verify fields are preserved
+    assert_eq!(cloned.commands.len(), 1);
+    assert_eq!(cloned.commands[0].duration_seconds, Some(5400));
+    assert_eq!(cloned.commands[0].target_soc_percent, Some(90));
+}
+
+#[rocket::async_test]
+async fn test_update_preserves_duration_and_soc() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    // Create an item
+    let new_item = json!({
+        "name": "Update Fields Test",
+        "commands": []
+    });
+
+    let response = client
+        .post("/api/1/Sites/1/ScheduleLibraryItems")
+        .cookie(admin_cookie.clone())
+        .json(&new_item)
+        .dispatch()
+        .await;
+    let created: ScheduleLibraryItem = response.into_json().await.expect("valid JSON");
+
+    // Update with duration and SOC
+    let update = json!({
+        "commands": [
+            {
+                "execution_offset_seconds": 43200,
+                "command_type": "discharge",
+                "duration_seconds": 1800,
+                "target_soc_percent": 20
+            }
+        ]
+    });
+
+    let url = format!("/api/1/ScheduleLibraryItems/{}", created.id);
+    let response = client.put(&url).cookie(admin_cookie.clone()).json(&update).dispatch().await;
+
+    assert_eq!(response.status(), Status::Ok);
+    let updated: ScheduleLibraryItem = response.into_json().await.expect("valid JSON");
+
+    assert_eq!(updated.commands.len(), 1);
+    assert_eq!(updated.commands[0].duration_seconds, Some(1800));
+    assert_eq!(updated.commands[0].target_soc_percent, Some(20));
+}


### PR DESCRIPTION
Extends the schedule_commands table with two new optional fields:
- duration_seconds: operation duration in seconds (must be positive)
- target_soc_percent: target state of charge percentage (0-100)

Backend changes:
- Add database migration with CHECK constraints
- Update ScheduleCommand, NewScheduleCommand, ScheduleCommandDto models
- Update ORM layer (create, get, update, clone operations)
- Add validation for new fields
- Bump version to 0.1.5

Resolves #36