### PR TITLE
Add ramp_duration_seconds to Site settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "neems-api"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "argon2",
  "built",

--- a/neems-admin/src/admin_cli/site_commands.rs
+++ b/neems-admin/src/admin_cli/site_commands.rs
@@ -207,8 +207,16 @@ pub fn site_add_impl(
         return Ok(());
     }
 
-    let created_site =
-        insert_site(conn, name, address, latitude, longitude, company_id, Some(admin_user_id))?;
+    let created_site = insert_site(
+        conn,
+        name,
+        address,
+        latitude,
+        longitude,
+        company_id,
+        120, // Default ramp duration
+        Some(admin_user_id),
+    )?;
 
     println!("Site created successfully!");
     println!("ID: {}", created_site.id);
@@ -350,6 +358,7 @@ pub fn site_edit_impl(
         new_latitude,
         new_longitude,
         new_company_id,
+        None, // ramp_duration_seconds - not modified by admin CLI
         Some(admin_user_id),
     )?;
 

--- a/neems-admin/src/main.rs
+++ b/neems-admin/src/main.rs
@@ -429,6 +429,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site");
@@ -1034,6 +1035,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site 1");
@@ -1044,6 +1046,7 @@ mod tests {
             41.0,
             -75.0,
             company.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site 2");
@@ -1066,6 +1069,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site 1");
@@ -1076,6 +1080,7 @@ mod tests {
             41.0,
             -75.0,
             company.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site 2");
@@ -1103,6 +1108,7 @@ mod tests {
             40.0,
             -74.0,
             company1.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site A");
@@ -1113,6 +1119,7 @@ mod tests {
             41.0,
             -75.0,
             company2.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site B");
@@ -1196,6 +1203,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site");
@@ -1206,6 +1214,7 @@ mod tests {
             41.0,
             -75.0,
             company.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site");
@@ -1237,6 +1246,7 @@ mod tests {
             40.0,
             -74.0,
             company1.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site 1");
@@ -1247,6 +1257,7 @@ mod tests {
             41.0,
             -75.0,
             company2.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site 2");
@@ -1394,6 +1405,7 @@ mod tests {
             40.0,
             -74.0,
             company1.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site");
@@ -1471,6 +1483,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             Some(1),
         )
         .expect("Failed to create site");
@@ -1608,6 +1621,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to create site");
@@ -1646,6 +1660,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             None,
         )
         .expect("Failed to create site");
@@ -1692,6 +1707,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             None,
         )
         .expect("Failed to create site");
@@ -1740,6 +1756,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             None,
         )
         .expect("Failed to create site");
@@ -1791,6 +1808,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             None,
         )
         .expect("Failed to create site 1");
@@ -1802,6 +1820,7 @@ mod tests {
             41.0,
             -75.0,
             company.id,
+            120,
             None,
         )
         .expect("Failed to create site 2");
@@ -1850,6 +1869,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to create site");
@@ -1888,6 +1908,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to create site");
@@ -1943,6 +1964,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             None,
         )
         .expect("Failed to create site");
@@ -2000,6 +2022,7 @@ mod tests {
             40.0,
             -74.0,
             company1.id,
+            120,
             None,
         )
         .expect("Failed to create site 1");
@@ -2011,6 +2034,7 @@ mod tests {
             41.0,
             -75.0,
             company2.id,
+            120,
             None,
         )
         .expect("Failed to create site 2");

--- a/neems-api/Cargo.toml
+++ b/neems-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neems-api"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 default-run = "neems-api"
 

--- a/neems-api/migrations/2026-03-15-220000_add_ramp_duration_seconds/down.sql
+++ b/neems-api/migrations/2026-03-15-220000_add_ramp_duration_seconds/down.sql
@@ -1,0 +1,44 @@
+-- SQLite doesn't support DROP COLUMN directly, so we need to recreate the table
+-- This migration removes the ramp_duration_seconds column from sites
+
+-- Create a temporary table without the ramp_duration_seconds column
+CREATE TABLE sites_backup (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name TEXT NOT NULL,
+    address TEXT NOT NULL,
+    latitude REAL NOT NULL,
+    longitude REAL NOT NULL,
+    company_id INTEGER NOT NULL REFERENCES companies(id) ON DELETE CASCADE
+);
+
+-- Copy data to backup table
+INSERT INTO sites_backup (id, name, address, latitude, longitude, company_id)
+SELECT id, name, address, latitude, longitude, company_id FROM sites;
+
+-- Drop the original table
+DROP TABLE sites;
+
+-- Rename backup to original
+ALTER TABLE sites_backup RENAME TO sites;
+
+-- Recreate triggers for entity_activity
+CREATE TRIGGER IF NOT EXISTS track_sites_insert
+AFTER INSERT ON sites
+BEGIN
+    INSERT INTO entity_activity (table_name, entity_id, operation_type, timestamp)
+    VALUES ('sites', NEW.id, 'create', datetime('now'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS track_sites_update
+AFTER UPDATE ON sites
+BEGIN
+    INSERT INTO entity_activity (table_name, entity_id, operation_type, timestamp)
+    VALUES ('sites', NEW.id, 'update', datetime('now'));
+END;
+
+CREATE TRIGGER IF NOT EXISTS track_sites_delete
+AFTER DELETE ON sites
+BEGIN
+    INSERT INTO entity_activity (table_name, entity_id, operation_type, timestamp)
+    VALUES ('sites', OLD.id, 'delete', datetime('now'));
+END;

--- a/neems-api/migrations/2026-03-15-220000_add_ramp_duration_seconds/up.sql
+++ b/neems-api/migrations/2026-03-15-220000_add_ramp_duration_seconds/up.sql
@@ -1,0 +1,4 @@
+-- Add ramp_duration_seconds column to sites table
+-- This configures the ConEd ramp rate constraint (time to ramp from 0 to full power)
+-- Default is 120 seconds
+ALTER TABLE sites ADD COLUMN ramp_duration_seconds INTEGER NOT NULL DEFAULT 120;

--- a/neems-api/src/api/site.rs
+++ b/neems-api/src/api/site.rs
@@ -39,6 +39,11 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+/// Default ramp duration in seconds (120 = 2 minutes)
+fn default_ramp_duration() -> i32 {
+    120
+}
+
 /// Request payload for creating a new site
 #[derive(Deserialize, Serialize, TS)]
 #[ts(export)]
@@ -48,6 +53,8 @@ pub struct CreateSiteRequest {
     pub latitude: f64,
     pub longitude: f64,
     pub company_id: i32,
+    #[serde(default = "default_ramp_duration")]
+    pub ramp_duration_seconds: i32,
 }
 
 /// Request payload for updating a site (all fields optional)
@@ -59,6 +66,7 @@ pub struct UpdateSiteRequest {
     pub latitude: Option<f64>,
     pub longitude: Option<f64>,
     pub company_id: Option<i32>,
+    pub ramp_duration_seconds: Option<i32>,
 }
 
 /// Helper function to check if user can perform CRUD operations on a site
@@ -164,6 +172,7 @@ pub async fn create_site(
                     new_site.latitude,
                     new_site.longitude,
                     new_site.company_id,
+                    new_site.ramp_duration_seconds,
                     Some(auth_user.user.id),
                 )
                 .map(|site| status::Created::new("/").body(Json(site)))
@@ -351,6 +360,7 @@ pub async fn update_site_endpoint(
                     update_data.latitude,
                     update_data.longitude,
                     update_data.company_id,
+                    update_data.ramp_duration_seconds,
                     Some(auth_user.user.id),
                 )
                 .map(Json)

--- a/neems-api/src/models/site.rs
+++ b/neems-api/src/models/site.rs
@@ -25,7 +25,8 @@ pub struct Site {
     pub address: String,
     pub latitude: f64,
     pub longitude: f64,
-    pub company_id: i32, // Foreign key to Company
+    pub company_id: i32,            // Foreign key to Company
+    pub ramp_duration_seconds: i32, // Time to ramp from 0 to full power (default 120s)
 }
 
 #[derive(Insertable)]
@@ -36,6 +37,7 @@ pub struct NewSite {
     pub latitude: f64,
     pub longitude: f64,
     pub company_id: i32,
+    pub ramp_duration_seconds: i32,
 }
 
 // For API inputs and validation
@@ -47,6 +49,7 @@ pub struct SiteInput {
     pub latitude: f64,
     pub longitude: f64,
     pub company_id: i32,
+    pub ramp_duration_seconds: i32,
 }
 
 // Response struct that includes computed timestamps from activity log
@@ -59,6 +62,7 @@ pub struct SiteWithTimestamps {
     pub latitude: f64,
     pub longitude: f64,
     pub company_id: i32,
+    pub ramp_duration_seconds: i32,
     #[ts(type = "string")]
     pub created_at: chrono::NaiveDateTime,
     #[ts(type = "string")]

--- a/neems-api/src/orm/device.rs
+++ b/neems-api/src/orm/device.rs
@@ -221,6 +221,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -270,6 +271,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -307,6 +309,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -349,6 +352,7 @@ mod tests {
             40.7589,
             -73.9851,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert second site");
@@ -387,6 +391,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -433,6 +438,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -484,6 +490,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site 1");
@@ -495,6 +502,7 @@ mod tests {
             40.7589,
             -73.9851,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site 2");
@@ -569,6 +577,7 @@ mod tests {
             40.0,
             -74.0,
             company1.id,
+            120,
             None,
         )
         .expect("Failed to insert site 1");
@@ -580,6 +589,7 @@ mod tests {
             41.0,
             -75.0,
             company2.id,
+            120,
             None,
         )
         .expect("Failed to insert site 2");
@@ -638,6 +648,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -717,6 +728,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -784,6 +796,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -837,6 +850,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -879,6 +893,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");

--- a/neems-api/src/orm/entity_activity.rs
+++ b/neems-api/src/orm/entity_activity.rs
@@ -393,6 +393,7 @@ pub fn test_all_triggers_comprehensive(
         40.7128,
         -74.0060,
         created_company.id,
+        120,
         None,
     )?;
 
@@ -409,6 +410,7 @@ pub fn test_all_triggers_comprehensive(
         conn,
         created_site.id,
         Some("Updated Site Name".to_string()),
+        None,
         None,
         None,
         None,

--- a/neems-api/src/orm/site.rs
+++ b/neems-api/src/orm/site.rs
@@ -24,6 +24,7 @@ pub fn insert_site(
     site_latitude: f64,
     site_longitude: f64,
     site_company_id: i32,
+    site_ramp_duration_seconds: i32,
     acting_user_id: Option<i32>,
 ) -> Result<Site, diesel::result::Error> {
     use crate::schema::sites::dsl::*;
@@ -34,6 +35,7 @@ pub fn insert_site(
         latitude: site_latitude,
         longitude: site_longitude,
         company_id: site_company_id,
+        ramp_duration_seconds: site_ramp_duration_seconds,
     };
 
     diesel::insert_into(sites).values(&new_site).execute(conn)?;
@@ -66,7 +68,7 @@ pub fn get_site_by_company_and_name(
     site_name: &str,
 ) -> Result<Option<Site>, diesel::result::Error> {
     // Use raw SQL for case-insensitive comparison
-    diesel::sql_query("SELECT id, name, address, latitude, longitude, company_id FROM sites WHERE company_id = ? AND LOWER(name) = LOWER(?)")
+    diesel::sql_query("SELECT id, name, address, latitude, longitude, company_id, ramp_duration_seconds FROM sites WHERE company_id = ? AND LOWER(name) = LOWER(?)")
         .bind::<diesel::sql_types::Integer, _>(site_company_id)
         .bind::<diesel::sql_types::Text, _>(site_name)
         .get_result::<Site>(conn)
@@ -89,6 +91,7 @@ pub fn update_site(
     new_latitude: Option<f64>,
     new_longitude: Option<f64>,
     new_company_id: Option<i32>,
+    new_ramp_duration_seconds: Option<i32>,
     acting_user_id: Option<i32>,
 ) -> Result<Site, diesel::result::Error> {
     use crate::schema::sites::dsl::*;
@@ -104,6 +107,8 @@ pub fn update_site(
             latitude.eq(new_latitude.unwrap_or(current_site.latitude)),
             longitude.eq(new_longitude.unwrap_or(current_site.longitude)),
             company_id.eq(new_company_id.unwrap_or(current_site.company_id)),
+            ramp_duration_seconds
+                .eq(new_ramp_duration_seconds.unwrap_or(current_site.ramp_duration_seconds)),
         ))
         .execute(conn)?;
 
@@ -163,6 +168,7 @@ pub fn get_site_with_timestamps(
         latitude: site.latitude,
         longitude: site.longitude,
         company_id: site.company_id,
+        ramp_duration_seconds: site.ramp_duration_seconds,
         created_at,
         updated_at,
     }))
@@ -188,6 +194,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site 1");
@@ -199,6 +206,7 @@ mod tests {
             40.7589,
             -73.9851,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site 2");
@@ -224,6 +232,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -233,6 +242,7 @@ mod tests {
         assert_eq!(site.latitude, 40.7128);
         assert_eq!(site.longitude, -74.0060);
         assert_eq!(site.company_id, company.id);
+        assert_eq!(site.ramp_duration_seconds, 120);
         assert!(site.id > 0);
     }
 
@@ -250,6 +260,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -285,6 +296,7 @@ mod tests {
             40.0,
             -74.0,
             company1.id,
+            120,
             None,
         )
         .expect("Failed to insert site 1");
@@ -295,6 +307,7 @@ mod tests {
             41.0,
             -75.0,
             company2.id,
+            120,
             None,
         )
         .expect("Failed to insert site 2");
@@ -305,6 +318,7 @@ mod tests {
             42.0,
             -76.0,
             company1.id,
+            120,
             None,
         )
         .expect("Failed to insert site 3");
@@ -334,6 +348,7 @@ mod tests {
             40.0,
             -74.0,
             company1.id,
+            120,
             None,
         )
         .expect("Failed to insert site");
@@ -360,6 +375,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .expect("Failed to update site");
 
@@ -368,6 +384,7 @@ mod tests {
         assert_eq!(updated_site.latitude, 40.0);
         assert_eq!(updated_site.longitude, -74.0);
         assert_eq!(updated_site.company_id, company1.id);
+        assert_eq!(updated_site.ramp_duration_seconds, 120); // Should remain unchanged
 
         // Check timestamps from activity log
         let new_created_at =
@@ -389,6 +406,7 @@ mod tests {
             Some(41.0),
             Some(-75.0),
             Some(company2.id),
+            Some(180),
             None,
         )
         .expect("Failed to fully update site");
@@ -398,14 +416,24 @@ mod tests {
         assert_eq!(fully_updated_site.latitude, 41.0);
         assert_eq!(fully_updated_site.longitude, -75.0);
         assert_eq!(fully_updated_site.company_id, company2.id);
+        assert_eq!(fully_updated_site.ramp_duration_seconds, 180);
     }
 
     #[test]
     fn test_update_nonexistent_site() {
         let mut conn = setup_test_db();
 
-        let result =
-            update_site(&mut conn, 99999, Some("Test".to_string()), None, None, None, None, None);
+        let result = update_site(
+            &mut conn,
+            99999,
+            Some("Test".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
 
         assert!(result.is_err());
     }
@@ -424,6 +452,7 @@ mod tests {
             40.0,
             -74.0,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site 1");
@@ -434,6 +463,7 @@ mod tests {
             41.0,
             -75.0,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site 2");
@@ -480,6 +510,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .unwrap();
@@ -495,6 +526,7 @@ mod tests {
         assert_eq!(site_with_timestamps.latitude, 40.7128);
         assert_eq!(site_with_timestamps.longitude, -74.0060);
         assert_eq!(site_with_timestamps.company_id, company.id);
+        assert_eq!(site_with_timestamps.ramp_duration_seconds, 120);
 
         // Timestamps should be recent (within last few seconds)
         let now = chrono::Utc::now().naive_utc();
@@ -520,6 +552,7 @@ mod tests {
             40.7128,
             -74.0060,
             company.id,
+            120,
             None,
         )
         .expect("Failed to insert site");

--- a/neems-api/src/schema.rs
+++ b/neems-api/src/schema.rs
@@ -128,6 +128,7 @@ diesel::table! {
         latitude -> Double,
         longitude -> Double,
         company_id -> Integer,
+        ramp_duration_seconds -> Integer,
     }
 }
 


### PR DESCRIPTION
Add a new field to sites table to configure the ConEd ramp rate constraint (time to ramp from 0 to full power, default 120 seconds).

- Add database migration for ramp_duration_seconds column
- Update Site, NewSite, SiteInput, and SiteWithTimestamps models
- Update insert_site and update_site ORM functions
- Add field to CreateSiteRequest (with default) and UpdateSiteRequest
- Update all test calls across neems-api and neems-admin

Closes #37