### PR TITLE
Bump version to 0.3.0 for alarm type exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "neems-api"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "argon2",
  "built",

--- a/neems-api/Cargo.toml
+++ b/neems-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neems-api"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 default-run = "neems-api"
 


### PR DESCRIPTION
This PR bumps our published types package version to catch the most recent updates.