### PR TITLE
Add GET /api/1/Alarms/History endpoint with date range + alarm filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "neems-api"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "argon2",
  "built",

--- a/neems-api/Cargo.toml
+++ b/neems-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neems-api"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 default-run = "neems-api"
 

--- a/neems-api/src/api/alarm.rs
+++ b/neems-api/src/api/alarm.rs
@@ -246,13 +246,15 @@ pub async fn get_alarm_definitions(_user: AuthenticatedUser) -> Json<AlarmDefini
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct AlarmHistoryEntry {
-    /// ISO 8601 timestamp (UTC) of the reading in which the transition was observed.
+    /// ISO 8601 timestamp (UTC) of the reading in which the transition was
+    /// observed.
     pub timestamp: String,
     pub alarm_num: u16,
     pub zone: AlarmZoneDto,
     pub name: String,
     pub severity: AlarmSeverityDto,
-    /// `true` if the alarm became active at this reading, `false` if it cleared.
+    /// `true` if the alarm became active at this reading, `false` if it
+    /// cleared.
     pub active: bool,
 }
 
@@ -275,7 +277,8 @@ pub struct AlarmHistoryQuery {
     pub from: Option<String>,
     /// ISO 8601 timestamp — end of the range (inclusive).
     pub to: Option<String>,
-    /// Comma-separated list of alarm_num values to filter on. Omitted = all alarms.
+    /// Comma-separated list of alarm_num values to filter on. Omitted = all
+    /// alarms.
     pub alarm_nums: Option<String>,
 }
 
@@ -289,15 +292,17 @@ fn parse_alarm_nums_filter(raw: &str) -> HashSet<u16> {
 
 /// Get alarm status transitions over a date range.
 ///
-/// - **URL:** `/api/1/Alarms/History?from=<ISO8601>&to=<ISO8601>&alarm_nums=<u16,u16,...>`
+/// - **URL:** `/api/1/Alarms/History?from=<ISO8601>&to=<ISO8601>&
+///   alarm_nums=<u16,u16,...>`
 /// - **Method:** `GET`
 /// - **Authentication:** Required
 ///
-/// Walks readings in `[from, to]`, decodes each reading's alarm register bitfield, and
-/// emits a transition entry each time a given alarm's active bit flips relative to the
-/// prior reading in range. Does not seed a baseline from before `from`, so a transition
-/// that occurred right before the range start won't appear — extend the range to
-/// capture it, or cross-reference with `/Alarms/Active` for current state.
+/// Walks readings in `[from, to]`, decodes each reading's alarm register
+/// bitfield, and emits a transition entry each time a given alarm's active bit
+/// flips relative to the prior reading in range. Does not seed a baseline from
+/// before `from`, so a transition that occurred right before the range start
+/// won't appear — extend the range to capture it, or cross-reference with
+/// `/Alarms/Active` for current state.
 #[get("/1/Alarms/History?<query..>")]
 pub async fn get_alarm_history(
     query: AlarmHistoryQuery,
@@ -311,7 +316,8 @@ pub async fn get_alarm_history(
     if from_dt > to_dt {
         return Err(Status::BadRequest);
     }
-    let alarm_filter: Option<HashSet<u16>> = query.alarm_nums.as_deref().map(parse_alarm_nums_filter);
+    let alarm_filter: Option<HashSet<u16>> =
+        query.alarm_nums.as_deref().map(parse_alarm_nums_filter);
 
     let from_naive = from_dt.naive_utc();
     let to_naive = to_dt.naive_utc();
@@ -337,7 +343,9 @@ pub async fn get_alarm_history(
     let mut prev_flags: Option<AlarmFlags> = None;
 
     for reading in &readings {
-        let Some(regs) = parse_alarm_registers(&reading.data) else { continue };
+        let Some(regs) = parse_alarm_registers(&reading.data) else {
+            continue;
+        };
         let flags = AlarmFlags::from_registers(&regs);
 
         if let Some(prev) = &prev_flags {

--- a/neems-api/src/api/alarm.rs
+++ b/neems-api/src/api/alarm.rs
@@ -3,12 +3,14 @@
 //! This module provides HTTP endpoints for accessing alarm information
 //! derived from RTAC readings stored in the site database.
 
-use chrono::Utc;
+use std::collections::HashSet;
+
+use chrono::{DateTime, Utc};
 use neems_data::rtac::{
     alarm_definitions::{ALARM_DEFINITIONS, ALARM_REGISTER_COUNT, AlarmDefinition, AlarmZone},
     state::AlarmFlags,
 };
-use rocket::{Route, http::Status, serde::json::Json};
+use rocket::{FromForm, Route, http::Status, serde::json::Json};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -145,7 +147,7 @@ pub struct AlarmDefinitionsResponse {
 ///
 /// Returns the alarm registers array if the data contains a valid
 /// `alarm_registers` field with exactly ALARM_REGISTER_COUNT elements.
-fn parse_alarm_registers(data_json: &str) -> Option<[u16; ALARM_REGISTER_COUNT]> {
+pub fn parse_alarm_registers(data_json: &str) -> Option<[u16; ALARM_REGISTER_COUNT]> {
     let parsed: serde_json::Value = serde_json::from_str(data_json).ok()?;
     let arr = parsed.get("alarm_registers")?.as_array()?;
     if arr.len() != ALARM_REGISTER_COUNT {
@@ -238,7 +240,134 @@ pub async fn get_alarm_definitions(_user: AuthenticatedUser) -> Json<AlarmDefini
     Json(AlarmDefinitionsResponse { definitions, total_count })
 }
 
+// --- Alarm history ---
+
+/// A single alarm-state transition emitted by the history endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct AlarmHistoryEntry {
+    /// ISO 8601 timestamp (UTC) of the reading in which the transition was observed.
+    pub timestamp: String,
+    pub alarm_num: u16,
+    pub zone: AlarmZoneDto,
+    pub name: String,
+    pub severity: AlarmSeverityDto,
+    /// `true` if the alarm became active at this reading, `false` if it cleared.
+    pub active: bool,
+}
+
+/// Response for the alarm-history endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct AlarmHistoryResponse {
+    pub entries: Vec<AlarmHistoryEntry>,
+    /// Echo of the requested range start (ISO 8601).
+    pub from: String,
+    /// Echo of the requested range end (ISO 8601).
+    pub to: String,
+}
+
+/// Query parameters for `GET /1/Alarms/History`.
+#[derive(Debug, Clone, FromForm, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct AlarmHistoryQuery {
+    /// ISO 8601 timestamp — start of the range (inclusive).
+    pub from: Option<String>,
+    /// ISO 8601 timestamp — end of the range (inclusive).
+    pub to: Option<String>,
+    /// Comma-separated list of alarm_num values to filter on. Omitted = all alarms.
+    pub alarm_nums: Option<String>,
+}
+
+fn parse_iso8601(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s).ok().map(|dt| dt.with_timezone(&Utc))
+}
+
+fn parse_alarm_nums_filter(raw: &str) -> HashSet<u16> {
+    raw.split(',').filter_map(|t| t.trim().parse::<u16>().ok()).collect()
+}
+
+/// Get alarm status transitions over a date range.
+///
+/// - **URL:** `/api/1/Alarms/History?from=<ISO8601>&to=<ISO8601>&alarm_nums=<u16,u16,...>`
+/// - **Method:** `GET`
+/// - **Authentication:** Required
+///
+/// Walks readings in `[from, to]`, decodes each reading's alarm register bitfield, and
+/// emits a transition entry each time a given alarm's active bit flips relative to the
+/// prior reading in range. Does not seed a baseline from before `from`, so a transition
+/// that occurred right before the range start won't appear — extend the range to
+/// capture it, or cross-reference with `/Alarms/Active` for current state.
+#[get("/1/Alarms/History?<query..>")]
+pub async fn get_alarm_history(
+    query: AlarmHistoryQuery,
+    _user: AuthenticatedUser,
+    site_db: SiteDbConn,
+) -> Result<Json<AlarmHistoryResponse>, Status> {
+    let from_str = query.from.clone().ok_or(Status::BadRequest)?;
+    let to_str = query.to.clone().ok_or(Status::BadRequest)?;
+    let from_dt = parse_iso8601(&from_str).ok_or(Status::BadRequest)?;
+    let to_dt = parse_iso8601(&to_str).ok_or(Status::BadRequest)?;
+    if from_dt > to_dt {
+        return Err(Status::BadRequest);
+    }
+    let alarm_filter: Option<HashSet<u16>> = query.alarm_nums.as_deref().map(parse_alarm_nums_filter);
+
+    let from_naive = from_dt.naive_utc();
+    let to_naive = to_dt.naive_utc();
+
+    let readings: Vec<neems_data::models::Reading> = site_db
+        .run(move |conn| {
+            use diesel::prelude::*;
+            use neems_data::schema::readings::dsl::*;
+
+            readings
+                .filter(timestamp.ge(from_naive))
+                .filter(timestamp.le(to_naive))
+                .order(timestamp.asc())
+                .load(conn)
+                .map_err(|e| {
+                    eprintln!("Error loading readings for alarm history: {:?}", e);
+                    Status::InternalServerError
+                })
+        })
+        .await?;
+
+    let mut entries: Vec<AlarmHistoryEntry> = Vec::new();
+    let mut prev_flags: Option<AlarmFlags> = None;
+
+    for reading in &readings {
+        let Some(regs) = parse_alarm_registers(&reading.data) else { continue };
+        let flags = AlarmFlags::from_registers(&regs);
+
+        if let Some(prev) = &prev_flags {
+            for def in ALARM_DEFINITIONS.iter() {
+                if let Some(filter) = &alarm_filter {
+                    if !filter.contains(&def.alarm_num) {
+                        continue;
+                    }
+                }
+                let was_active = prev.is_alarm_active(def);
+                let is_active = flags.is_alarm_active(def);
+                if was_active != is_active {
+                    entries.push(AlarmHistoryEntry {
+                        timestamp: reading.timestamp.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+                        alarm_num: def.alarm_num,
+                        zone: def.zone.into(),
+                        name: def.name.to_string(),
+                        severity: AlarmSeverityDto::from_level(def.level),
+                        active: is_active,
+                    });
+                }
+            }
+        }
+        prev_flags = Some(flags);
+    }
+
+    Ok(Json(AlarmHistoryResponse { entries, from: from_str, to: to_str }))
+}
+
 /// Returns all routes defined in this module.
 pub fn routes() -> Vec<Route> {
-    routes![get_active_alarms, get_alarm_definitions]
+    routes![get_active_alarms, get_alarm_definitions, get_alarm_history]
 }

--- a/neems-api/src/generate_types.rs
+++ b/neems-api/src/generate_types.rs
@@ -129,7 +129,8 @@ mod tests {
         // Alarm API types
         use crate::api::alarm::{
             ActiveAlarmDto, ActiveAlarmsResponse, AlarmDefinitionDto, AlarmDefinitionsResponse,
-            AlarmSeverityDto, AlarmZoneDto,
+            AlarmHistoryEntry, AlarmHistoryQuery, AlarmHistoryResponse, AlarmSeverityDto,
+            AlarmZoneDto,
         };
         AlarmSeverityDto::export().expect("Failed to export AlarmSeverityDto type");
         AlarmZoneDto::export().expect("Failed to export AlarmZoneDto type");
@@ -137,6 +138,9 @@ mod tests {
         ActiveAlarmDto::export().expect("Failed to export ActiveAlarmDto type");
         ActiveAlarmsResponse::export().expect("Failed to export ActiveAlarmsResponse type");
         AlarmDefinitionsResponse::export().expect("Failed to export AlarmDefinitionsResponse type");
+        AlarmHistoryEntry::export().expect("Failed to export AlarmHistoryEntry type");
+        AlarmHistoryResponse::export().expect("Failed to export AlarmHistoryResponse type");
+        AlarmHistoryQuery::export().expect("Failed to export AlarmHistoryQuery type");
 
         // Data API types
         use crate::api::data::{DataSourcesResponse, ReadingsQuery, ReadingsResponse};


### PR DESCRIPTION
Walks readings in [from, to] in chronological order, decodes each reading's alarm_registers bitfield via AlarmFlags::from_registers, and emits a transition entry whenever an individual alarm's active bit flips relative to the previous reading in range. Supports an optional comma-separated alarm_nums filter so callers can scope the timeline to a single alarm.

Does not seed a baseline reading from before `from` — transitions that occurred right before the range start won't appear. Consumers should cross-reference with /Alarms/Active to identify the current state when rendering a "this is the current status" highlight.

Makes `parse_alarm_registers` public so the new handler can share the existing JSON-decode helper.

Bumps neems-api to 0.3.1 (patch — backward-compatible additions).

Closes Newtown-Energy/neems-core#49.