### PR TITLE
Record a change reason when creating a library item

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "neems-api"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "argon2",
  "built",

--- a/neems-api/Cargo.toml
+++ b/neems-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neems-api"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 default-run = "neems-api"
 

--- a/neems-api/src/models/schedule_library.rs
+++ b/neems-api/src/models/schedule_library.rs
@@ -159,6 +159,10 @@ pub struct CreateLibraryItemRequest {
     pub name: String,
     pub description: Option<String>,
     pub commands: Vec<CreateCommandRequest>,
+    /// Free-form reason for creating this schedule, surfaced in the
+    /// Change History pane. Optional on the wire so older/trigger-only
+    /// callers stay NULL, but the UI requires it on the create form.
+    pub change_reason: Option<String>,
 }
 
 /// Command data for creating/updating

--- a/neems-api/src/orm/schedule_library.rs
+++ b/neems-api/src/orm/schedule_library.rs
@@ -47,15 +47,26 @@ pub fn create_library_item(
             .get_result::<LastInsertRowId>(conn)?
             .last_insert_rowid as i32;
 
-        // Update activity log with user info
-        if let Some(user_id) = acting_user_id {
-            use crate::orm::entity_activity::update_latest_activity_user;
-            let _ = update_latest_activity_user(
+        // Update activity log with user info and the creation reason.
+        {
+            use crate::orm::entity_activity::{
+                update_latest_activity_reason, update_latest_activity_user,
+            };
+            if let Some(user_id) = acting_user_id {
+                let _ = update_latest_activity_user(
+                    conn,
+                    "schedule_templates",
+                    template_id,
+                    "create",
+                    user_id,
+                );
+            }
+            let _ = update_latest_activity_reason(
                 conn,
                 "schedule_templates",
                 template_id,
                 "create",
-                user_id,
+                request.change_reason.as_deref(),
             );
         }
 
@@ -196,7 +207,12 @@ pub fn create_library_item_from_site_defaults(
     create_library_item(
         conn,
         site_id,
-        CreateLibraryItemRequest { name, description, commands },
+        CreateLibraryItemRequest {
+            name,
+            description,
+            commands,
+            change_reason: Some("Created from site defaults".to_string()),
+        },
         acting_user_id,
     )
 }
@@ -482,6 +498,7 @@ pub fn clone_library_item(
                 target_soc_percent: cmd.target_soc_percent,
             })
             .collect(),
+        change_reason: Some(format!("Cloned from '{}'", original.name)),
     };
 
     create_library_item(conn, original.site_id, create_request, acting_user_id)


### PR DESCRIPTION
Editing an existing schedule's commands already requires a reason (stored on the update activity row). Creating a new schedule did not capture one.

- Add `change_reason: Option<String>` to `CreateLibraryItemRequest`.
- `create_library_item` writes that reason to the "create" `entity_activity` row (mirroring `update_library_item`), so a newly-created schedule appears in the change history with its why.
- Internal callers supply sensible defaults: from-site-defaults records "Created from site defaults"; clone records "Cloned from '<name>'".

Pairs with the frontend change (neems-react) that adds a required "Reason for change" field to the Create New Schedule dialog.

Verified: build + `cargo fmt` + clippy clean (no warnings in changed file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)