### PR TITLE
Validate numeric bounds on Site update / Site create / wizard

### DIFF
--- a/neems-api/src/api/schedule_library.rs
+++ b/neems-api/src/api/schedule_library.rs
@@ -396,6 +396,16 @@ pub async fn create_library_item_from_site_defaults_endpoint(
 
         let req = request.into_inner();
 
+        if !(0..=100).contains(&req.end_of_charge_soc_percent) {
+            let err = Json(ErrorResponse {
+                error: format!(
+                    "end_of_charge_soc_percent must be between 0 and 100 (got {})",
+                    req.end_of_charge_soc_percent
+                ),
+            });
+            return Err(status::Custom(Status::BadRequest, err));
+        }
+
         match create_library_item_from_site_defaults(
             conn,
             site_id,

--- a/neems-api/src/api/site.rs
+++ b/neems-api/src/api/site.rs
@@ -153,6 +153,16 @@ pub async fn create_site(
         return Err(response::status::Custom(Status::Forbidden, err));
     }
 
+    if new_site.ramp_duration_seconds < 0 {
+        let err = Json(ErrorResponse {
+            error: format!(
+                "ramp_duration_seconds must be 0 or greater (got {})",
+                new_site.ramp_duration_seconds
+            ),
+        });
+        return Err(response::status::Custom(Status::BadRequest, err));
+    }
+
     db.run(move |conn| {
         // First validate that the company exists
         match get_company_by_id(conn, new_site.company_id) {
@@ -327,11 +337,16 @@ pub async fn update_site_endpoint(
     update_data: LoggedJson<UpdateSiteRequest>,
     auth_user: AuthenticatedUser,
 ) -> Result<Json<Site>, response::status::Custom<Json<ErrorResponse>>> {
-    // Reject out-of-range rate percentages before touching the DB so the
-    // caller gets a clear 400 instead of a quiet bad-data write.
+    // Reject out-of-range numeric fields before touching the DB so the
+    // caller gets a clear 400 instead of a quiet bad-data write. These
+    // mirror the bounds the React UI enforces.
     for (field, value) in [
         ("charge_rate_percent", update_data.charge_rate_percent),
         ("discharge_rate_percent", update_data.discharge_rate_percent),
+        (
+            "rebound_protection_soc_floor_percent",
+            update_data.rebound_protection_soc_floor_percent,
+        ),
     ] {
         if let Some(v) = value {
             if !v.is_finite() || !(0.0..=100.0).contains(&v) {
@@ -340,6 +355,33 @@ pub async fn update_site_endpoint(
                 });
                 return Err(response::status::Custom(Status::BadRequest, err));
             }
+        }
+    }
+
+    for (field, value) in [
+        ("power_kw", update_data.power_kw),
+        ("capacity_kwh", update_data.capacity_kwh),
+        (
+            "interconnection_max_output_kw",
+            update_data.interconnection_max_output_kw,
+        ),
+    ] {
+        if let Some(v) = value {
+            if !v.is_finite() || v < 0.0 {
+                let err = Json(ErrorResponse {
+                    error: format!("{} must be 0 or greater (got {})", field, v),
+                });
+                return Err(response::status::Custom(Status::BadRequest, err));
+            }
+        }
+    }
+
+    if let Some(v) = update_data.ramp_duration_seconds {
+        if v < 0 {
+            let err = Json(ErrorResponse {
+                error: format!("ramp_duration_seconds must be 0 or greater (got {})", v),
+            });
+            return Err(response::status::Custom(Status::BadRequest, err));
         }
     }
 


### PR DESCRIPTION
## Summary

- Mirrors the bounds the React UI enforces, so out-of-range values get a clear 400 instead of slipping into the database.
- `PUT /api/1/Sites/{id}`: `rebound_protection_soc_floor_percent` joins the existing 0–100 percent checks; `power_kw`, `capacity_kwh`, `interconnection_max_output_kw`, and `ramp_duration_seconds` must be 0 or greater.
- `POST /api/1/Sites`: `ramp_duration_seconds` must be 0 or greater.
- `POST /api/1/Sites/{id}/ScheduleLibraryItems/FromSiteDefaults`: `end_of_charge_soc_percent` must be 0–100.

## Test plan

- [ ] PUT with `power_kw: -1` → 400 with `must be 0 or greater`
- [ ] PUT with `rebound_protection_soc_floor_percent: 150` → 400 with `must be between 0 and 100`
- [ ] PUT with all positive values → 200, site updated
- [ ] Wizard `FromSiteDefaults` with `end_of_charge_soc_percent: 120` → 400
- [ ] Existing in-range data still saves through Site Settings UI unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)