### PR TITLE
Site bounds validation + Trickle charge limit + dev-env unblocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "neems-api"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "argon2",
  "built",

--- a/neems-api/Cargo.toml
+++ b/neems-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neems-api"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 default-run = "neems-api"
 

--- a/neems-api/diesel.toml
+++ b/neems-api/diesel.toml
@@ -4,10 +4,12 @@
 [print_schema]
 file = "src/schema.rs"
 custom_type_derives = ["diesel::query_builder::QueryId", "Clone"]
-# Applied after schema regeneration. Forces sites.latitude / longitude
-# to `Double` (f64) instead of diesel-cli's SQLite default of `Float`
-# (f32); the Site model is keyed to f64 and CLI-driven migrations
-# were silently flipping the schema back, breaking the build.
+# print-schema regenerates schema.rs from the live DB on every
+# `diesel migration run`. The schedule_templates table's physical
+# column order (is_active, created_at, is_default) does not match
+# the Rust ScheduleTemplate struct's field order — so without this
+# patch the post-migration build fails with 7 trait-bound errors.
+# The patch swaps created_at and is_default back to struct order.
 patch_file = "src/schema.patch"
 
 [migrations_directory]

--- a/neems-api/docker-entrypoint.sh
+++ b/neems-api/docker-entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# Cap debug info to line tables (debuginfo=1) so the linker's peak
+# memory during parallel test-binary links stays under the Docker VM
+# allocation. Full debug info (debuginfo=2) was tipping aarch64 debug
+# links over ~1.5 GB each — when cargo ran 3-4 in parallel ld would
+# get OOM-killed (signal 9). debuginfo=1 keeps line numbers (so panics
+# still point at real source lines) without the full DWARF type tree.
+export RUSTFLAGS="${RUSTFLAGS} -C debuginfo=1"
+
 # Run database migrations
 echo "Running database migrations..."
 cd /usr/src/app/neems-api

--- a/neems-api/migrations/2026-06-05-100000_add_trickle_charge_limit/down.sql
+++ b/neems-api/migrations/2026-06-05-100000_add_trickle_charge_limit/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sites DROP COLUMN trickle_charge_power_kw;

--- a/neems-api/migrations/2026-06-05-100000_add_trickle_charge_limit/up.sql
+++ b/neems-api/migrations/2026-06-05-100000_add_trickle_charge_limit/up.sql
@@ -1,0 +1,6 @@
+-- Per-site trickle-charge power limit (kW). Used as the commanded
+-- power level whenever a schedule emits a `trickle_charge` command.
+-- Nullable so existing rows are left as "no limit configured"; the
+-- consuming code falls back to a sensible default when null.
+
+ALTER TABLE sites ADD COLUMN trickle_charge_power_kw DOUBLE PRECISION;

--- a/neems-api/src/api/schedule_library.rs
+++ b/neems-api/src/api/schedule_library.rs
@@ -396,6 +396,16 @@ pub async fn create_library_item_from_site_defaults_endpoint(
 
         let req = request.into_inner();
 
+        if !(0..=100).contains(&req.end_of_charge_soc_percent) {
+            let err = Json(ErrorResponse {
+                error: format!(
+                    "end_of_charge_soc_percent must be between 0 and 100 (got {})",
+                    req.end_of_charge_soc_percent
+                ),
+            });
+            return Err(status::Custom(Status::BadRequest, err));
+        }
+
         match create_library_item_from_site_defaults(
             conn,
             site_id,

--- a/neems-api/src/api/site.rs
+++ b/neems-api/src/api/site.rs
@@ -154,6 +154,16 @@ pub async fn create_site(
         return Err(response::status::Custom(Status::Forbidden, err));
     }
 
+    if new_site.ramp_duration_seconds < 0 {
+        let err = Json(ErrorResponse {
+            error: format!(
+                "ramp_duration_seconds must be 0 or greater (got {})",
+                new_site.ramp_duration_seconds
+            ),
+        });
+        return Err(response::status::Custom(Status::BadRequest, err));
+    }
+
     db.run(move |conn| {
         // First validate that the company exists
         match get_company_by_id(conn, new_site.company_id) {
@@ -328,11 +338,16 @@ pub async fn update_site_endpoint(
     update_data: LoggedJson<UpdateSiteRequest>,
     auth_user: AuthenticatedUser,
 ) -> Result<Json<Site>, response::status::Custom<Json<ErrorResponse>>> {
-    // Reject out-of-range rate percentages before touching the DB so the
-    // caller gets a clear 400 instead of a quiet bad-data write.
+    // Reject out-of-range numeric fields before touching the DB so the
+    // caller gets a clear 400 instead of a quiet bad-data write. These
+    // mirror the bounds the React UI enforces.
     for (field, value) in [
         ("charge_rate_percent", update_data.charge_rate_percent),
         ("discharge_rate_percent", update_data.discharge_rate_percent),
+        (
+            "rebound_protection_soc_floor_percent",
+            update_data.rebound_protection_soc_floor_percent,
+        ),
     ] {
         if let Some(v) = value {
             if !v.is_finite() || !(0.0..=100.0).contains(&v) {
@@ -344,10 +359,29 @@ pub async fn update_site_endpoint(
         }
     }
 
-    if let Some(v) = update_data.trickle_charge_power_kw {
-        if !v.is_finite() || v < 0.0 {
+    for (field, value) in [
+        ("power_kw", update_data.power_kw),
+        ("capacity_kwh", update_data.capacity_kwh),
+        (
+            "interconnection_max_output_kw",
+            update_data.interconnection_max_output_kw,
+        ),
+        ("trickle_charge_power_kw", update_data.trickle_charge_power_kw),
+    ] {
+        if let Some(v) = value {
+            if !v.is_finite() || v < 0.0 {
+                let err = Json(ErrorResponse {
+                    error: format!("{} must be 0 or greater (got {})", field, v),
+                });
+                return Err(response::status::Custom(Status::BadRequest, err));
+            }
+        }
+    }
+
+    if let Some(v) = update_data.ramp_duration_seconds {
+        if v < 0 {
             let err = Json(ErrorResponse {
-                error: format!("trickle_charge_power_kw must be 0 or greater (got {})", v),
+                error: format!("ramp_duration_seconds must be 0 or greater (got {})", v),
             });
             return Err(response::status::Custom(Status::BadRequest, err));
         }

--- a/neems-api/src/api/site.rs
+++ b/neems-api/src/api/site.rs
@@ -362,10 +362,7 @@ pub async fn update_site_endpoint(
     for (field, value) in [
         ("power_kw", update_data.power_kw),
         ("capacity_kwh", update_data.capacity_kwh),
-        (
-            "interconnection_max_output_kw",
-            update_data.interconnection_max_output_kw,
-        ),
+        ("interconnection_max_output_kw", update_data.interconnection_max_output_kw),
         ("trickle_charge_power_kw", update_data.trickle_charge_power_kw),
     ] {
         if let Some(v) = value {

--- a/neems-api/src/api/site.rs
+++ b/neems-api/src/api/site.rs
@@ -85,6 +85,7 @@ pub struct UpdateSiteRequest {
     pub site_variant: Option<String>,
     pub charge_rate_percent: Option<f64>,
     pub discharge_rate_percent: Option<f64>,
+    pub trickle_charge_power_kw: Option<f64>,
 }
 
 /// Helper function to check if user can perform CRUD operations on a site
@@ -343,6 +344,15 @@ pub async fn update_site_endpoint(
         }
     }
 
+    if let Some(v) = update_data.trickle_charge_power_kw {
+        if !v.is_finite() || v < 0.0 {
+            let err = Json(ErrorResponse {
+                error: format!("trickle_charge_power_kw must be 0 or greater (got {})", v),
+            });
+            return Err(response::status::Custom(Status::BadRequest, err));
+        }
+    }
+
     db.run(move |conn| {
         // First get the site to check authorization
         match get_site_by_id(conn, site_id) {
@@ -409,6 +419,7 @@ pub async fn update_site_endpoint(
                         site_variant: update_data.site_variant.clone(),
                         charge_rate_percent: update_data.charge_rate_percent,
                         discharge_rate_percent: update_data.discharge_rate_percent,
+                        trickle_charge_power_kw: update_data.trickle_charge_power_kw,
                     },
                     Some(auth_user.user.id),
                 )

--- a/neems-api/src/models/site.rs
+++ b/neems-api/src/models/site.rs
@@ -76,6 +76,10 @@ pub struct Site {
     /// Discharge ceiling as a percentage of `power_kw` (0–100). See
     /// `charge_rate_percent` for visualization context.
     pub discharge_rate_percent: f64,
+    /// Commanded power for `trickle_charge` schedule commands, in kW.
+    /// Nullable so existing rows are interpreted as "unset" and the
+    /// consumer falls back to a default.
+    pub trickle_charge_power_kw: Option<f64>,
 }
 
 #[derive(Insertable)]
@@ -97,6 +101,7 @@ pub struct NewSite {
     pub peak_revenue_start_minutes: Option<i32>,
     pub peak_revenue_end_minutes: Option<i32>,
     pub interconnection_max_output_kw: Option<f64>,
+    pub trickle_charge_power_kw: Option<f64>,
 }
 
 // For API inputs and validation
@@ -134,6 +139,7 @@ pub struct SiteWithTimestamps {
     pub site_variant: String,
     pub charge_rate_percent: f64,
     pub discharge_rate_percent: f64,
+    pub trickle_charge_power_kw: Option<f64>,
     #[ts(type = "string")]
     pub created_at: chrono::NaiveDateTime,
     #[ts(type = "string")]

--- a/neems-api/src/orm/site.rs
+++ b/neems-api/src/orm/site.rs
@@ -38,6 +38,7 @@ pub struct SiteUpdate {
     pub site_variant: Option<String>,
     pub charge_rate_percent: Option<f64>,
     pub discharge_rate_percent: Option<f64>,
+    pub trickle_charge_power_kw: Option<f64>,
 }
 
 /// Gets all sites for a specific company ID.
@@ -81,6 +82,7 @@ pub fn insert_site(
         peak_revenue_start_minutes: Some(DEFAULT_PEAK_REVENUE_START_MINUTES),
         peak_revenue_end_minutes: Some(DEFAULT_PEAK_REVENUE_END_MINUTES),
         interconnection_max_output_kw: Some(DEFAULT_INTERCONNECTION_MAX_OUTPUT_KW),
+        trickle_charge_power_kw: None,
     };
 
     diesel::insert_into(sites).values(&new_site).execute(conn)?;
@@ -118,7 +120,7 @@ pub fn get_site_by_company_and_name(
          power_kw, capacity_kwh, closed_loop_enabled, off_peak_start_minutes, \
          off_peak_end_minutes, peak_revenue_start_minutes, peak_revenue_end_minutes, \
          interconnection_max_output_kw, rebound_protection_soc_floor_percent, site_variant, \
-         charge_rate_percent, discharge_rate_percent \
+         charge_rate_percent, discharge_rate_percent, trickle_charge_power_kw \
          FROM sites WHERE company_id = ? AND LOWER(name) = LOWER(?)",
     )
     .bind::<diesel::sql_types::Integer, _>(site_company_id)
@@ -178,6 +180,9 @@ pub fn update_site(
                 .eq(update.charge_rate_percent.unwrap_or(current_site.charge_rate_percent)),
             discharge_rate_percent
                 .eq(update.discharge_rate_percent.unwrap_or(current_site.discharge_rate_percent)),
+            trickle_charge_power_kw.eq(update
+                .trickle_charge_power_kw
+                .or(current_site.trickle_charge_power_kw)),
         ))
         .execute(conn)?;
 
@@ -248,6 +253,7 @@ pub fn get_site_with_timestamps(
         site_variant: site.site_variant,
         charge_rate_percent: site.charge_rate_percent,
         discharge_rate_percent: site.discharge_rate_percent,
+        trickle_charge_power_kw: site.trickle_charge_power_kw,
         created_at,
         updated_at,
     }))

--- a/neems-api/src/orm/site.rs
+++ b/neems-api/src/orm/site.rs
@@ -180,9 +180,8 @@ pub fn update_site(
                 .eq(update.charge_rate_percent.unwrap_or(current_site.charge_rate_percent)),
             discharge_rate_percent
                 .eq(update.discharge_rate_percent.unwrap_or(current_site.discharge_rate_percent)),
-            trickle_charge_power_kw.eq(update
-                .trickle_charge_power_kw
-                .or(current_site.trickle_charge_power_kw)),
+            trickle_charge_power_kw
+                .eq(update.trickle_charge_power_kw.or(current_site.trickle_charge_power_kw)),
         ))
         .execute(conn)?;
 

--- a/neems-api/src/schema.patch
+++ b/neems-api/src/schema.patch
@@ -1,13 +1,10 @@
 --- a/src/schema.rs
 +++ b/src/schema.rs
-@@ -125,8 +125,8 @@ diesel::table! {
-         id -> Integer,
-         name -> Text,
-         address -> Text,
--        latitude -> Float,
--        longitude -> Float,
-+        latitude -> Double,
-+        longitude -> Double,
-         company_id -> Integer,
-         ramp_duration_seconds -> Integer,
-         power_kw -> Nullable<Double>,
+@@ -1,7 +1,7 @@
+         description -> Nullable<Text>,
+         is_active -> Bool,
+-        created_at -> Timestamp,
+         is_default -> Bool,
++        created_at -> Timestamp,
+     }
+ }

--- a/neems-api/src/schema.rs
+++ b/neems-api/src/schema.rs
@@ -142,6 +142,7 @@ diesel::table! {
         site_variant -> Text,
         charge_rate_percent -> Double,
         discharge_rate_percent -> Double,
+        trickle_charge_power_kw -> Nullable<Double>,
     }
 }
 


### PR DESCRIPTION
## Summary

Four concerns landed together on this branch — the bounds-validation work, a new per-site setting (trickle-charge limit), and two dev-env unblocks that surfaced while iterating against the running stack.

**API bounds validation** — Mirrors the bounds the React UI enforces, so out-of-range values get a clear 400 instead of slipping into the database.
- `PUT /api/1/Sites/{id}`: `rebound_protection_soc_floor_percent` joins the existing 0–100 percent checks; `power_kw`, `capacity_kwh`, `interconnection_max_output_kw`, `trickle_charge_power_kw` must be 0 or greater; `ramp_duration_seconds` must be 0 or greater.
- `POST /api/1/Sites`: `ramp_duration_seconds` must be 0 or greater.
- `POST /api/1/Sites/{id}/ScheduleLibraryItems/FromSiteDefaults`: `end_of_charge_soc_percent` must be 0–100.

**Trickle charge limit** — New `trickle_charge_power_kw` column on `sites` (nullable `DOUBLE`), surfaced through `Site`, `SiteWithTimestamps`, and `UpdateSiteRequest`, persisted via the existing site update path. Existing rows default to NULL so they stay "unset" until an operator configures a value.

**Dev-env: cap debug info to line tables** — `RUSTFLAGS="-C debuginfo=1"` in `neems-api/docker-entrypoint.sh`. Full DWARF was pushing each aarch64 debug link of a neems-api test binary past ~1.5 GB, and cargo's parallel link fanout was getting OOM-killed by the Linux OOM-killer inside the Docker VM (signal 9). Line tables keep panic backtraces pointing at real source without the full type tree.

**Dev-env: repurpose `schema.patch`** — After `diesel migration run` the CLI regenerates `schema.rs` from the live DB. The `schedule_templates` table's physical column order (`is_active, created_at, is_default`) does not match the Rust struct's field order (`is_active, is_default, created_at`), so the post-regen build was failing with 7 diesel trait-bound errors. The historical `schema.patch` only flipped `sites.latitude/longitude` from Float to Double — but the diesel-cli version we run now emits Double natively, so that hunk was a Reversed-or-applied no-op that aborted the patch step entirely. New patch swaps the `schedule_templates` fields back to struct order.

The frontend counterpart that consumes the new `trickle_charge_power_kw` column lives in Newtown-Energy/neems-react#83. Merging this PR first lets the migration run before the frontend ships.

## Test plan

- [ ] Fresh `docker compose up` against a clean DB applies the migration and Rocket launches without "Failed to apply patch"
- [ ] `PUT /api/1/Sites/{id}` with `trickle_charge_power_kw: 200` round-trips and persists
- [ ] `PUT /api/1/Sites/{id}` with `power_kw: -1` → 400 with "must be 0 or greater"
- [ ] `PUT /api/1/Sites/{id}` with `rebound_protection_soc_floor_percent: 150` → 400 with "must be between 0 and 100"
- [ ] `POST /api/1/Sites` with `ramp_duration_seconds: -1` → 400
- [ ] Wizard `FromSiteDefaults` with `end_of_charge_soc_percent: 120` → 400
- [ ] `GET /api/1/Sites` shows `trickle_charge_power_kw: null` for previously-existing rows
- [ ] Existing in-range data still saves through Site Settings UI unchanged
- [ ] Confirm parallel test links no longer OOM with `cargo test --features test-staging generate_typescript_types` inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)