### PR TITLE
Add shared OData helper and apply query options to /Devices

### DIFF
--- a/neems-api/src/api/company.rs
+++ b/neems-api/src/api/company.rs
@@ -16,7 +16,10 @@ use ts_rs::TS;
 use crate::{
     company::{get_company_by_name_case_insensitive, insert_company},
     models::{Company, CompanyInput, Site, UserWithRoles},
-    odata_query::ODataQuery,
+    odata_query::{
+        ODataCollectionResponse, ODataField, ODataQuery, apply_query, apply_select,
+        build_context_url,
+    },
     orm::{
         DbConn,
         company::{delete_company, get_all_companies},
@@ -162,63 +165,12 @@ pub async fn list_companies(
         .run(|conn| get_all_companies(conn).map_err(|_| Status::InternalServerError))
         .await?;
 
-    // Apply filtering if specified
-    let mut filtered_companies = companies;
-    if let Some(filter_expr) = query.parse_filter() {
-        // Basic filtering implementation
-        filtered_companies.retain(|company| {
-            match &filter_expr.property.as_str() {
-                &"name" => match &filter_expr.value {
-                    crate::odata_query::FilterValue::String(s) => match filter_expr.operator {
-                        crate::odata_query::FilterOperator::Eq => company.name == *s,
-                        crate::odata_query::FilterOperator::Ne => company.name != *s,
-                        crate::odata_query::FilterOperator::Contains => company.name.contains(s),
-                        _ => true,
-                    },
-                    _ => true,
-                },
-                _ => true, // Unknown property, don't filter
-            }
-        });
-    }
-
-    // Apply ordering
-    if let Some(order_props) = query.parse_orderby() {
-        for (property, direction) in order_props {
-            match property.as_str() {
-                "name" => {
-                    filtered_companies.sort_by(|a, b| {
-                        let cmp = a.name.cmp(&b.name);
-                        match direction {
-                            crate::odata_query::OrderDirection::Asc => cmp,
-                            crate::odata_query::OrderDirection::Desc => cmp.reverse(),
-                        }
-                    });
-                }
-                "id" => {
-                    filtered_companies.sort_by(|a, b| {
-                        let cmp = a.id.cmp(&b.id);
-                        match direction {
-                            crate::odata_query::OrderDirection::Asc => cmp,
-                            crate::odata_query::OrderDirection::Desc => cmp.reverse(),
-                        }
-                    });
-                }
-                _ => {} // Unknown property, don't sort
-            }
-        }
-    }
-
-    // Get count before applying top/skip
-    let total_count = filtered_companies.len() as i64;
-
-    // Apply skip and top
-    if let Some(skip) = query.skip {
-        filtered_companies = filtered_companies.into_iter().skip(skip as usize).collect();
-    }
-    if let Some(top) = query.top {
-        filtered_companies = filtered_companies.into_iter().take(top as usize).collect();
-    }
+    // Apply $filter, $orderby, $skip, and $top.
+    let fields = [
+        ODataField::str("name", |c: &Company| c.name.clone()),
+        ODataField::int("id", |c: &Company| c.id as i64),
+    ];
+    let (filtered_companies, total_count) = apply_query(companies, &query, &fields);
 
     // Handle $expand first, then $select
     let expand_props = query.parse_expand();
@@ -272,19 +224,14 @@ pub async fn list_companies(
     let select_props = query.parse_select();
     let selected_companies: Result<Vec<serde_json::Value>, _> = expanded_companies
         .iter()
-        .map(|company| crate::odata_query::apply_select(company, select_props.as_deref()))
+        .map(|company| apply_select(company, select_props.as_deref()))
         .collect();
 
     let selected_companies = selected_companies.map_err(|_| Status::InternalServerError)?;
 
     // Build OData response
-    let context = crate::odata_query::build_context_url(
-        "http://localhost/api/1",
-        "Companies",
-        select_props.as_deref(),
-    );
-    let mut response =
-        crate::odata_query::ODataCollectionResponse::new(context, selected_companies);
+    let context = build_context_url("http://localhost/api/1", "Companies", select_props.as_deref());
+    let mut response = ODataCollectionResponse::new(context, selected_companies);
 
     // Add count if requested
     if query.count.unwrap_or(false) {

--- a/neems-api/src/api/device.rs
+++ b/neems-api/src/api/device.rs
@@ -16,7 +16,10 @@ use ts_rs::TS;
 
 use crate::{
     models::{Device, DeviceInput},
-    odata_query::ODataQuery,
+    odata_query::{
+        ODataCollectionResponse, ODataField, ODataQuery, apply_query, apply_select,
+        build_context_url,
+    },
     orm::{
         DbConn,
         device::{
@@ -257,38 +260,66 @@ pub async fn create_device(
 ///   ]
 /// }
 /// ```
-#[get("/1/Devices?<_query..>")]
+#[get("/1/Devices?<query..>")]
 pub async fn list_devices(
     db: DbConn,
     auth_user: AuthenticatedUser,
-    _query: ODataQuery,
+    query: ODataQuery,
 ) -> Result<Json<serde_json::Value>, Status> {
-    db.run(move |conn| {
-        let devices = if auth_user.has_any_role(&["newtown-admin", "newtown-staff"]) {
-            // Newtown roles can see all devices
-            match get_all_devices(conn) {
-                Ok(devices) => devices,
-                Err(_) => return Err(Status::InternalServerError),
+    // Validate query options
+    query.validate().map_err(|_| Status::BadRequest)?;
+
+    // Authorization: newtown roles see all devices, everyone else is scoped to
+    // their own company.
+    let is_newtown = auth_user.has_any_role(&["newtown-admin", "newtown-staff"]);
+    let company_id = auth_user.user.company_id;
+    let devices = db
+        .run(move |conn| {
+            if is_newtown {
+                get_all_devices(conn)
+            } else {
+                get_devices_by_company(conn, company_id)
             }
-        } else {
-            // Regular users can only see devices in their company
-            match get_devices_by_company(conn, auth_user.user.company_id) {
-                Ok(devices) => devices,
-                Err(_) => return Err(Status::InternalServerError),
-            }
-        };
+            .map_err(|_| Status::InternalServerError)
+        })
+        .await?;
 
-        // TODO: Apply OData query options (filtering, sorting, pagination)
-        // For now, return all devices without query processing
+    // Apply $filter, $orderby, $skip, and $top.
+    //
+    // Nullable fields collapse NULL to "" via `unwrap_or_default()`, so a NULL
+    // serial filters/sorts identically to an empty string. `install_date` is
+    // intentionally omitted: there's no date-typed accessor variant.
+    let fields = [
+        ODataField::str("name", |d: &Device| d.name.clone()),
+        ODataField::str("type_", |d: &Device| d.type_.clone()),
+        ODataField::str("model", |d: &Device| d.model.clone()),
+        ODataField::str("serial", |d: &Device| d.serial.clone().unwrap_or_default()),
+        ODataField::str("ip_address", |d: &Device| d.ip_address.clone().unwrap_or_default()),
+        ODataField::str("description", |d: &Device| d.description.clone().unwrap_or_default()),
+        ODataField::int("id", |d: &Device| d.id as i64),
+        ODataField::int("company_id", |d: &Device| d.company_id as i64),
+        ODataField::int("site_id", |d: &Device| d.site_id as i64),
+    ];
+    let (filtered_devices, total_count) = apply_query(devices, &query, &fields);
 
-        let response = serde_json::json!({
-            "@odata.context": "http://localhost/api/1/$metadata#Devices",
-            "value": devices
-        });
+    // Apply $select to each device if specified.
+    let select_props = query.parse_select();
+    let selected_devices: Result<Vec<serde_json::Value>, _> = filtered_devices
+        .iter()
+        .map(|device| apply_select(device, select_props.as_deref()))
+        .collect();
+    let selected_devices = selected_devices.map_err(|_| Status::InternalServerError)?;
 
-        Ok(Json(response))
-    })
-    .await
+    // Build OData response
+    let context = build_context_url("http://localhost/api/1", "Devices", select_props.as_deref());
+    let mut response = ODataCollectionResponse::new(context, selected_devices);
+
+    // Add count if requested
+    if query.count.unwrap_or(false) {
+        response = response.with_count(total_count);
+    }
+
+    Ok(Json(serde_json::to_value(response).map_err(|_| Status::InternalServerError)?))
 }
 
 /// Get Device endpoint.

--- a/neems-api/src/api/user/list.rs
+++ b/neems-api/src/api/user/list.rs
@@ -3,7 +3,11 @@
 use rocket::{http::Status, serde::json::Json};
 
 use crate::{
-    odata_query::{ODataCollectionResponse, ODataQuery, apply_select, build_context_url},
+    models::UserWithRoles,
+    odata_query::{
+        ODataCollectionResponse, ODataField, ODataQuery, apply_query, apply_select,
+        build_context_url,
+    },
     orm::{
         DbConn,
         user::{get_users_by_company_with_roles, list_all_users_with_roles},
@@ -88,64 +92,13 @@ pub async fn list_users(
         return Err(Status::Forbidden);
     };
 
-    // Apply filtering if specified
-    let mut filtered_users = users;
-    if let Some(filter_expr) = query.parse_filter() {
-        // Basic filtering implementation - this could be expanded
-        filtered_users.retain(|user| {
-            // Simple implementation - could be much more sophisticated
-            match &filter_expr.property.as_str() {
-                &"email" => match &filter_expr.value {
-                    crate::odata_query::FilterValue::String(s) => match filter_expr.operator {
-                        crate::odata_query::FilterOperator::Eq => user.email == *s,
-                        crate::odata_query::FilterOperator::Ne => user.email != *s,
-                        crate::odata_query::FilterOperator::Contains => user.email.contains(s),
-                        _ => true,
-                    },
-                    _ => true,
-                },
-                _ => true, // Unknown property, don't filter
-            }
-        });
-    }
-
-    // Apply sorting if specified
-    if let Some(orderby) = query.parse_orderby() {
-        for (property, direction) in orderby.iter().rev() {
-            match property.as_str() {
-                "email" => {
-                    filtered_users.sort_by(|a, b| {
-                        let cmp = a.email.cmp(&b.email);
-                        match direction {
-                            crate::odata_query::OrderDirection::Asc => cmp,
-                            crate::odata_query::OrderDirection::Desc => cmp.reverse(),
-                        }
-                    });
-                }
-                "id" => {
-                    filtered_users.sort_by(|a, b| {
-                        let cmp = a.id.cmp(&b.id);
-                        match direction {
-                            crate::odata_query::OrderDirection::Asc => cmp,
-                            crate::odata_query::OrderDirection::Desc => cmp.reverse(),
-                        }
-                    });
-                }
-                _ => {} // Unknown property, don't sort
-            }
-        }
-    }
-
-    // Get count before applying top/skip
-    let total_count = filtered_users.len() as i64;
-
-    // Apply skip and top
-    if let Some(skip) = query.skip {
-        filtered_users = filtered_users.into_iter().skip(skip as usize).collect();
-    }
-    if let Some(top) = query.top {
-        filtered_users = filtered_users.into_iter().take(top as usize).collect();
-    }
+    // Apply $filter, $orderby, $skip, and $top.
+    let fields = [
+        ODataField::str("email", |u: &UserWithRoles| u.email.clone()),
+        ODataField::int("id", |u: &UserWithRoles| u.id as i64),
+        ODataField::int("company_id", |u: &UserWithRoles| u.company_id as i64),
+    ];
+    let (filtered_users, total_count) = apply_query(users, &query, &fields);
 
     // Handle $expand and computed properties, then $select
     let expand_props = query.parse_expand();

--- a/neems-api/src/odata_query.rs
+++ b/neems-api/src/odata_query.rs
@@ -99,6 +99,154 @@ pub enum OrderDirection {
     Desc,
 }
 
+/// Accessor used by [`apply_query`] to read a sortable/filterable property off
+/// an in-memory entity. The variant determines which comparison and filter
+/// operators apply.
+///
+/// Note: [`FilterExpression::parse`] currently only produces `eq`/`ne`/`lt`/
+/// `le`/`gt`/`ge`, so the string-only operators below are handled here but not
+/// yet reachable from a `$filter` query string.
+pub enum FieldAccessor<T> {
+    /// Text property. Supports `eq`, `ne`, `contains`, `startswith`, and
+    /// `endswith` filtering plus lexicographic ordering.
+    Str(Box<dyn Fn(&T) -> String + Send + Sync>),
+    /// Integer property. Supports `eq`, `ne`, `lt`, `le`, `gt`, and `ge`
+    /// filtering plus numeric ordering.
+    Int(Box<dyn Fn(&T) -> i64 + Send + Sync>),
+}
+
+/// A single OData-addressable property: the name clients use in `$filter` and
+/// `$orderby`, paired with the accessor that reads it off an entity.
+pub struct ODataField<T> {
+    pub name: &'static str,
+    pub accessor: FieldAccessor<T>,
+}
+
+impl<T> ODataField<T> {
+    /// Declare a text property addressable as `name`.
+    pub fn str(name: &'static str, get: impl Fn(&T) -> String + Send + Sync + 'static) -> Self {
+        Self {
+            name,
+            accessor: FieldAccessor::Str(Box::new(get)),
+        }
+    }
+
+    /// Declare an integer property addressable as `name`.
+    pub fn int(name: &'static str, get: impl Fn(&T) -> i64 + Send + Sync + 'static) -> Self {
+        Self {
+            name,
+            accessor: FieldAccessor::Int(Box::new(get)),
+        }
+    }
+}
+
+/// Apply `$filter`, `$orderby`, `$skip`, and `$top` to an in-memory collection.
+///
+/// `fields` declares which properties are addressable and how to read them;
+/// unknown properties (and value-type mismatches) in `$filter`/`$orderby` are
+/// ignored rather than rejected — the collection is left unchanged for that
+/// clause. This is lenient by design; callers wanting strict 400s on unknown
+/// properties would need to validate the clause against `fields` first.
+///
+/// The whole collection is materialized before this runs: callers fetch every
+/// row, then this filters/sorts/paginates in memory. Fine for the current
+/// table sizes; revisit if any collection grows large.
+///
+/// Only single-clause `$filter` expressions are understood (see
+/// [`FilterExpression::parse`]); compound `and`/`or` filters are not parsed and
+/// will match nothing.
+///
+/// Returns the processed collection together with the total count *after*
+/// filtering but *before* pagination, suitable for `$count`.
+pub fn apply_query<T>(
+    mut items: Vec<T>,
+    query: &ODataQuery,
+    fields: &[ODataField<T>],
+) -> (Vec<T>, i64) {
+    // $filter
+    if let Some(filter) = query.parse_filter() {
+        items.retain(|item| matches_filter(item, &filter, fields));
+    }
+
+    // $orderby. Apply keys least-significant first so a stable sort yields the
+    // requested multi-key ordering.
+    if let Some(orderby) = query.parse_orderby() {
+        for (property, direction) in orderby.iter().rev() {
+            let Some(field) = fields.iter().find(|f| f.name == property) else {
+                continue; // Unknown property, don't sort.
+            };
+            items.sort_by(|a, b| {
+                let cmp = compare_field(a, b, &field.accessor);
+                match direction {
+                    OrderDirection::Asc => cmp,
+                    OrderDirection::Desc => cmp.reverse(),
+                }
+            });
+        }
+    }
+
+    // Count reflects the filtered set, independent of pagination.
+    let total_count = items.len() as i64;
+
+    // $skip / $top. `validate()` already rejects negatives; the `max(0)` guards
+    // are belt-and-suspenders since `apply_query` doesn't validate itself.
+    if let Some(skip) = query.skip {
+        items = items.into_iter().skip(skip.max(0) as usize).collect();
+    }
+    if let Some(top) = query.top {
+        items = items.into_iter().take(top.max(0) as usize).collect();
+    }
+
+    (items, total_count)
+}
+
+/// Evaluate a parsed `$filter` against one entity. Returns `true` (keep the
+/// item) when the property is unknown or the value type is incompatible.
+fn matches_filter<T>(item: &T, filter: &FilterExpression, fields: &[ODataField<T>]) -> bool {
+    let Some(field) = fields.iter().find(|f| f.name == filter.property) else {
+        return true; // Unknown property, don't filter it out.
+    };
+
+    match &field.accessor {
+        FieldAccessor::Str(get) => {
+            let FilterValue::String(rhs) = &filter.value else {
+                return true; // Type mismatch, leave the item in place.
+            };
+            let lhs = get(item);
+            match filter.operator {
+                FilterOperator::Eq => lhs == *rhs,
+                FilterOperator::Ne => lhs != *rhs,
+                FilterOperator::Contains => lhs.contains(rhs.as_str()),
+                FilterOperator::StartsWith => lhs.starts_with(rhs.as_str()),
+                FilterOperator::EndsWith => lhs.ends_with(rhs.as_str()),
+                _ => true,
+            }
+        }
+        FieldAccessor::Int(get) => {
+            let FilterValue::Integer(rhs) = &filter.value else {
+                return true; // Type mismatch, leave the item in place.
+            };
+            let lhs = get(item);
+            match filter.operator {
+                FilterOperator::Eq => lhs == *rhs,
+                FilterOperator::Ne => lhs != *rhs,
+                FilterOperator::Lt => lhs < *rhs,
+                FilterOperator::Le => lhs <= *rhs,
+                FilterOperator::Gt => lhs > *rhs,
+                FilterOperator::Ge => lhs >= *rhs,
+                _ => true,
+            }
+        }
+    }
+}
+
+fn compare_field<T>(a: &T, b: &T, accessor: &FieldAccessor<T>) -> std::cmp::Ordering {
+    match accessor {
+        FieldAccessor::Str(get) => get(a).cmp(&get(b)),
+        FieldAccessor::Int(get) => get(a).cmp(&get(b)),
+    }
+}
+
 /// Basic filter expression support (simplified implementation)
 #[derive(Debug, Clone)]
 pub struct FilterExpression {

--- a/neems-api/tests/device_api.rs
+++ b/neems-api/tests/device_api.rs
@@ -681,3 +681,135 @@ async fn test_device_rbac_newtown_admin() {
 
     assert_eq!(response.status(), Status::Created);
 }
+
+/// Helper to create a device and return the parsed result.
+async fn create_device(
+    client: &Client,
+    admin_cookie: &rocket::http::Cookie<'static>,
+    company_id: i32,
+    site_id: i32,
+    name: &str,
+    type_: &str,
+    model: &str,
+) -> Device {
+    let new_device = json!({
+        "name": name,
+        "type_": type_,
+        "model": model,
+        "company_id": company_id,
+        "site_id": site_id
+    });
+
+    let response = client
+        .post("/api/1/Devices")
+        .cookie(admin_cookie.clone())
+        .json(&new_device)
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Created);
+    response.into_json().await.expect("valid device JSON")
+}
+
+/// Helper to GET /Devices with a query string and return the parsed OData body.
+async fn list_devices_query(
+    client: &Client,
+    admin_cookie: &rocket::http::Cookie<'static>,
+    query: &str,
+) -> serde_json::Value {
+    let response = client
+        .get(format!("/api/1/Devices?{query}"))
+        .cookie(admin_cookie.clone())
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::Ok);
+    response.into_json().await.expect("valid OData JSON")
+}
+
+#[rocket::async_test]
+async fn test_list_devices_odata_filter_and_select() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+    let company = get_company_by_name(&client, &admin_cookie, "Device Test Company A").await;
+    let site = get_site_by_name(&client, &admin_cookie, "Device API Site A").await;
+
+    create_device(&client, &admin_cookie, company.id, site.id, "ZZQ Alpha", "Inverter", "QM-1")
+        .await;
+    create_device(&client, &admin_cookie, company.id, site.id, "ZZQ Bravo", "Sensor", "QM-2").await;
+
+    // $filter by exact name returns only the matching device (URI-encoded
+    // spaces and quotes).
+    let body =
+        list_devices_query(&client, &admin_cookie, "$filter=name%20eq%20%27ZZQ%20Bravo%27").await;
+    let value = body["value"].as_array().expect("value array");
+    assert_eq!(value.len(), 1);
+    assert_eq!(value[0]["name"], "ZZQ Bravo");
+
+    // $filter eq combined with $select returns only the requested property.
+    let body = list_devices_query(
+        &client,
+        &admin_cookie,
+        "$filter=name%20eq%20%27ZZQ%20Alpha%27&$select=name",
+    )
+    .await;
+    let value = body["value"].as_array().expect("value array");
+    assert_eq!(value.len(), 1);
+    let obj = value[0].as_object().expect("device object");
+    assert_eq!(obj.get("name").and_then(|v| v.as_str()), Some("ZZQ Alpha"));
+    assert!(obj.get("model").is_none(), "$select=name should drop other fields");
+    assert!(obj.get("id").is_none(), "$select=name should drop other fields");
+}
+
+#[rocket::async_test]
+async fn test_list_devices_odata_orderby_count_and_pagination() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+    let company = get_company_by_name(&client, &admin_cookie, "Device Test Company A").await;
+    let site = get_site_by_name(&client, &admin_cookie, "Device API Site A").await;
+
+    create_device(&client, &admin_cookie, company.id, site.id, "PgN Gamma", "Sensor", "PG-3").await;
+    create_device(&client, &admin_cookie, company.id, site.id, "PgN Alpha", "Sensor", "PG-1").await;
+    create_device(&client, &admin_cookie, company.id, site.id, "PgN Beta", "Sensor", "PG-2").await;
+
+    // $orderby ascending yields a name-sorted collection.
+    let body = list_devices_query(&client, &admin_cookie, "$orderby=name").await;
+    let names: Vec<String> = body["value"]
+        .as_array()
+        .expect("value array")
+        .iter()
+        .map(|d| d["name"].as_str().unwrap().to_string())
+        .collect();
+    let mut sorted = names.clone();
+    sorted.sort();
+    assert_eq!(names, sorted, "$orderby=name should return ascending order");
+
+    // $count reports the full filtered total, independent of $top.
+    let body = list_devices_query(&client, &admin_cookie, "$count=true&$top=1").await;
+    let total = body["@odata.count"].as_i64().expect("@odata.count present");
+    assert_eq!(body["value"].as_array().expect("value array").len(), 1);
+    assert!(total >= 3, "count should reflect all devices, not just the $top page");
+
+    // $skip + $top page through the ordered collection.
+    let page = list_devices_query(&client, &admin_cookie, "$orderby=name&$top=2&$skip=1").await;
+    let page_names: Vec<String> = page["value"]
+        .as_array()
+        .expect("value array")
+        .iter()
+        .map(|d| d["name"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(page_names.len(), 2);
+    assert_eq!(page_names, &sorted[1..3], "page should be items 2 and 3 of the sorted list");
+}
+
+#[rocket::async_test]
+async fn test_list_devices_invalid_query_rejected() {
+    let client = Client::tracked(fast_test_rocket()).await.expect("valid rocket instance");
+    let admin_cookie = login_admin(&client).await;
+
+    // $top out of range is rejected by ODataQuery::validate.
+    let response = client
+        .get("/api/1/Devices?$top=99999")
+        .cookie(admin_cookie.clone())
+        .dispatch()
+        .await;
+    assert_eq!(response.status(), Status::BadRequest);
+}


### PR DESCRIPTION
## Why

`/Users` and `/Companies` each carried near-identical hand-rolled `$filter`/`$orderby`/`$top`/`$skip` logic, while `/Devices` silently ignored OData query options entirely. That left clients written against the OData contract getting inconsistent behavior across collections, and made adding query support to any new collection a copy-paste exercise.

## What

- **Closes #58** — Extract a shared OData filter/sort/paginate helper (`apply_query` + `ODataField` descriptors) in `odata_query.rs`. `/Users` and `/Companies` now delegate to it, removing the duplicated blocks.
- **Closes #54** — `/Devices` now honors `$filter`, `$orderby`, `$top`, `$skip`, `$select`, and `$count` via the shared helper.

## Notes

- The helper handles `contains`/`startswith`/`endswith` for string fields, but the existing `$filter` parser only emits `eq`/`ne`/`lt`/`le`/`gt`/`ge`, so those string operators aren't reachable from a query string yet (documented inline; small follow-up to wire into the parser).
- Multi-key `$orderby` is now applied least-significant-key-first (a stable-sort correctness fix; `/Companies` previously didn't). Single-key ordering is unchanged.

## Testing

`cargo build` clean, `dosh lint-clippy` clean, `cargo fmt` applied. Passing: `device_api` (17, incl. new filter/select, orderby/count/pagination, and invalid-`$top` tests), `company` (4), `odata_expand` (15), `odata_navigation` (8), `user_comprehensive` (8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)