### PR TITLE
Demo mode: RTAC off by default + history injection endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ endpoint and the React dashboard.
   stays read-only and logs a warning.
 - It runs on its own thread with a current-thread runtime because the Modbus
   client context is not `Send`.
-- Disable it with `RTAC_ENABLED=0` (or `false`/`no`).
+- Disabled by default so the system doesn't follow a (possibly absent) RTAC
+  connection. Enable it with `RTAC_ENABLED=1` (or `true`/`yes`/`on`).
 
 ## Development Workflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "neems-api"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "argon2",
  "built",

--- a/neems-api/Cargo.toml
+++ b/neems-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neems-api"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 default-run = "neems-api"
 

--- a/neems-api/src/api/demo.rs
+++ b/neems-api/src/api/demo.rs
@@ -1,0 +1,129 @@
+//! Demo-only API endpoints.
+//!
+//! These exist to make a hardware-free demo look real: rather than the
+//! frontend writing a pile of fake data, it asks the backend to generate
+//! plausible multi-day SoC and alarm history server-side (reusing the same
+//! generators as the `neems-data seed-*-history` CLI commands).
+//!
+//! Gated to the same roles as the Demo Controls drawer. Meant to be deleted
+//! once the real RTAC feed is the source of truth.
+
+use neems_data::{SeedOutcome, seed_alarm_history, seed_soc_history};
+use rocket::{Route, http::Status, serde::json::Json};
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+use crate::{orm::neems_data::db::SiteDbConn, session_guards::AuthenticatedUser};
+
+/// Roles allowed to drive demo controls — mirrors the frontend drawer's gate
+/// and the forced-alarm endpoints in [`crate::api::alarm`].
+const DEMO_CONTROL_ROLES: &[&str] = &["admin", "newtown-admin", "newtown-staff"];
+
+/// Default days of history to backfill when the request omits it.
+const DEFAULT_DAYS: u32 = 14;
+/// Cap so a stray request can't try to generate an unbounded amount of data.
+const MAX_DAYS: u32 = 90;
+/// Sample cadence; matches the RTAC collector / seeder default of 6 minutes.
+const INTERVAL_MINUTES: u32 = 6;
+
+/// Body for `POST /1/Demo/InjectHistory`.
+#[derive(Debug, Clone, Deserialize, TS)]
+#[ts(export)]
+pub struct InjectHistoryRequest {
+    pub site_id: i32,
+    /// Days of history to backfill. Defaults to 14, clamped to 1..=90.
+    #[serde(default)]
+    pub days: Option<u32>,
+}
+
+/// Per-source result of a seed run.
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export)]
+pub struct SeedSummary {
+    pub source_name: String,
+    /// New readings written this run.
+    pub written: u32,
+    /// Slots skipped because a reading already existed there.
+    pub already_present: u32,
+    /// Total slots spanned by the window.
+    pub total_slots: u32,
+}
+
+impl From<SeedOutcome> for SeedSummary {
+    fn from(o: SeedOutcome) -> Self {
+        SeedSummary {
+            source_name: o.source_name,
+            written: o.written as u32,
+            already_present: o.already_present as u32,
+            total_slots: o.total_slots as u32,
+        }
+    }
+}
+
+/// Response for `POST /1/Demo/InjectHistory`.
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export)]
+pub struct InjectHistoryResponse {
+    pub site_id: i32,
+    pub days: u32,
+    pub soc: SeedSummary,
+    pub alarms: SeedSummary,
+}
+
+fn forbid_unless_demo_role(user: &AuthenticatedUser) -> Result<(), Status> {
+    if user.has_any_role(DEMO_CONTROL_ROLES) {
+        Ok(())
+    } else {
+        Err(Status::Forbidden)
+    }
+}
+
+/// Inject simulated SoC + alarm history for a site.
+///
+/// - **URL:** `/api/1/Demo/InjectHistory`
+/// - **Method:** `POST`
+/// - **Body:** `{ "site_id": i32, "days"?: u32 }`
+/// - **Authentication:** Required; one of `admin`, `newtown-admin`,
+///   `newtown-staff`.
+///
+/// Backfills the last `days` (default 14) of plausible SoC and alarm readings
+/// for the site at a 6-minute cadence. Idempotent: re-running only fills slots
+/// that aren't already present, so it's safe to call repeatedly (e.g. to keep
+/// the trailing window fresh as days pass).
+#[post("/1/Demo/InjectHistory", data = "<body>")]
+pub async fn inject_history(
+    user: AuthenticatedUser,
+    site_db: SiteDbConn,
+    body: Json<InjectHistoryRequest>,
+) -> Result<Json<InjectHistoryResponse>, Status> {
+    forbid_unless_demo_role(&user)?;
+
+    let site_id = body.site_id;
+    let days = body.days.unwrap_or(DEFAULT_DAYS).clamp(1, MAX_DAYS);
+
+    let response = site_db
+        .run(move |conn| {
+            let soc = seed_soc_history(conn, site_id, days, INTERVAL_MINUTES).map_err(|e| {
+                eprintln!("Demo inject: SoC seeding failed for site {site_id}: {e}");
+                Status::InternalServerError
+            })?;
+            let alarms =
+                seed_alarm_history(conn, site_id, days, INTERVAL_MINUTES).map_err(|e| {
+                    eprintln!("Demo inject: alarm seeding failed for site {site_id}: {e}");
+                    Status::InternalServerError
+                })?;
+            Ok::<InjectHistoryResponse, Status>(InjectHistoryResponse {
+                site_id,
+                days,
+                soc: soc.into(),
+                alarms: alarms.into(),
+            })
+        })
+        .await?;
+
+    Ok(Json(response))
+}
+
+pub fn routes() -> Vec<Route> {
+    routes![inject_history]
+}

--- a/neems-api/src/api/mod.rs
+++ b/neems-api/src/api/mod.rs
@@ -8,6 +8,7 @@ pub mod alarm;
 pub mod application_rule;
 pub mod company;
 pub mod data;
+pub mod demo;
 pub mod device;
 pub mod entity_activity;
 #[cfg(feature = "fixphrase")]
@@ -40,6 +41,7 @@ pub fn routes() -> Vec<Route> {
     routes.extend(application_rule::routes());
     routes.extend(company::routes());
     routes.extend(data::routes());
+    routes.extend(demo::routes());
     routes.extend(device::routes());
     routes.extend(entity_activity::routes());
     routes.extend(login::routes());

--- a/neems-api/src/generate_types.rs
+++ b/neems-api/src/generate_types.rs
@@ -150,6 +150,12 @@ mod tests {
         ForcedAlarmsRequest::export().expect("Failed to export ForcedAlarmsRequest type");
         ForcedAlarmsResponse::export().expect("Failed to export ForcedAlarmsResponse type");
 
+        // Demo API types
+        use crate::api::demo::{InjectHistoryRequest, InjectHistoryResponse, SeedSummary};
+        InjectHistoryRequest::export().expect("Failed to export InjectHistoryRequest type");
+        SeedSummary::export().expect("Failed to export SeedSummary type");
+        InjectHistoryResponse::export().expect("Failed to export InjectHistoryResponse type");
+
         // Data API types
         use crate::api::data::{
             ChargeDischargeBucket, ChargeDischargeSummary, DataSourcesResponse, ReadingsQuery,

--- a/neems-data/src/lib.rs
+++ b/neems-data/src/lib.rs
@@ -16,8 +16,10 @@ pub mod collectors;
 pub mod models;
 pub mod rtac;
 pub mod schema;
+pub mod seed;
 
 pub use models::*;
+pub use seed::{SeedOutcome, seed_alarm_history, seed_soc_history, seeded_alarm_flags};
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 
@@ -64,15 +66,17 @@ impl DataAggregator {
         let database_url = self.database_url.clone();
 
         // Start the RTAC collector alongside the source poller. It polls the
-        // RTAC (or the simulated RTAC) and stores SoC readings. Enabled by
-        // default; set RTAC_ENABLED=0 (or false/no) to disable.
+        // RTAC (or the simulated RTAC) and stores SoC readings. Disabled by
+        // default so the system does not follow a (possibly absent) RTAC
+        // connection unless explicitly told to; set RTAC_ENABLED=1 (or
+        // true/yes) to enable.
         //
         // The Modbus client context is not `Send`, so the collector runs on its
         // own dedicated thread with a current-thread runtime rather than being
         // spawned onto the shared multi-thread runtime.
         let rtac_enabled = env::var("RTAC_ENABLED")
-            .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no"))
-            .unwrap_or(true);
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+            .unwrap_or(false);
         if rtac_enabled {
             let rtac_db_url = self.database_url.clone();
             std::thread::Builder::new().name("rtac-collector".to_string()).spawn(move || {

--- a/neems-data/src/main.rs
+++ b/neems-data/src/main.rs
@@ -1,15 +1,11 @@
 use std::{env, error::Error};
 
-use chrono::{Duration, NaiveDateTime, Utc};
 use clap::{Args, Parser, Subcommand};
 use dotenvy::dotenv;
 use neems_data::{
-    DataAggregator, NewReading, NewSource, UpdateSource,
-    collectors::data_sources::charging_state_with_level, create_source, delete_source,
-    get_source_by_name, insert_readings_batch, list_sources, rtac::state::AlarmFlags,
-    update_source,
+    DataAggregator, NewSource, UpdateSource, create_source, delete_source, get_source_by_name,
+    list_sources, update_source,
 };
-use serde_json::json;
 
 pub mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
@@ -513,10 +509,22 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             }
         }
         Some(Commands::SeedSocHistory(args)) => {
-            seed_soc_history(&mut connection, args)?;
+            let outcome = neems_data::seed_soc_history(
+                &mut connection,
+                args.site_id,
+                args.days,
+                args.interval_minutes,
+            )?;
+            report_seed("SoC", args.site_id, &outcome);
         }
         Some(Commands::SeedAlarmHistory(args)) => {
-            seed_alarm_history(&mut connection, args)?;
+            let outcome = neems_data::seed_alarm_history(
+                &mut connection,
+                args.site_id,
+                args.days,
+                args.interval_minutes,
+            )?;
+            report_seed("alarm", args.site_id, &outcome);
         }
         None => {
             eprintln!("No command provided. Use --help for usage information.");
@@ -527,280 +535,22 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     Ok(())
 }
 
-/// Backfill plausible past SoC readings for the given site.
-///
-/// Idempotent: collects existing reading timestamps for the source
-/// up-front and only writes slots that aren't already present.
-fn seed_soc_history(
-    conn: &mut diesel::SqliteConnection,
-    args: SeedSocHistoryArgs,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
-    use diesel::prelude::*;
-    use neems_data::schema::{readings, sources};
-
-    if args.interval_minutes == 0 {
-        return Err("--interval-minutes must be > 0".into());
-    }
-
-    // Ensure a charging_state source exists for this site. Reuse the
-    // existing one if present; otherwise create a deterministic name so
-    // re-runs find the same row.
-    let existing_source: Option<(Option<i32>, String)> = sources::table
-        .filter(sources::site_id.eq(args.site_id))
-        .filter(sources::test_type.eq("charging_state"))
-        .select((sources::id, sources::name))
-        .first(conn)
-        .optional()?;
-
-    let (source_id, source_name) = match existing_source {
-        Some((Some(id), name)) => (id, name),
-        Some((None, name)) => {
-            return Err(format!("source '{}' has NULL id (corrupt row?)", name).into());
-        }
-        None => {
-            let name = format!("soc_history_site_{}", args.site_id);
-            let new_source = NewSource {
-                name: name.clone(),
-                description: Some(format!("Demo SoC history for site {} (seeded)", args.site_id)),
-                active: Some(false), // seed-only; not polled live
-                interval_seconds: Some((args.interval_minutes as i32) * 60),
-                test_type: Some("charging_state".to_string()),
-                arguments: Some("{}".to_string()),
-                site_id: Some(args.site_id),
-                company_id: None,
-            };
-            let created = create_source(conn, new_source)?;
-            let id = created.id.ok_or("create_source returned a row with no id")?;
-            println!("Created source '{}' (ID {})", created.name, id);
-            (id, created.name)
-        }
-    };
-
-    // Build the slot grid (oldest → newest, top of the minute).
-    let interval = Duration::minutes(args.interval_minutes as i64);
-    let end = {
-        let now = Utc::now().naive_utc();
-        // Snap to the most recent slot boundary so re-runs hit the same
-        // timestamps each time.
-        let secs = now.and_utc().timestamp();
-        let slot = interval.num_seconds();
-        let snapped = secs - (secs % slot);
-        chrono::DateTime::from_timestamp(snapped, 0)
-            .ok_or("failed to snap end timestamp")?
-            .naive_utc()
-    };
-    let start = end - Duration::days(args.days as i64);
-    // Loop below is inclusive on both endpoints, so the slot count is
-    // span/interval + 1 (e.g. a 6-min span at 6-min cadence yields 2
-    // slots, not 1). Without the +1 the "already present" math at the
-    // end can underflow when the seeder fully populates the window.
-    let total_slots = ((end - start).num_seconds() / interval.num_seconds()) as usize + 1;
-
-    // Idempotency: pull existing timestamps in the window and skip them.
-    let existing: std::collections::HashSet<NaiveDateTime> = readings::table
-        .filter(readings::source_id.eq(source_id))
-        .filter(readings::timestamp.ge(start))
-        .filter(readings::timestamp.le(end))
-        .select(readings::timestamp)
-        .load::<NaiveDateTime>(conn)?
-        .into_iter()
-        .collect();
-
-    let mut batch: Vec<NewReading> = Vec::new();
-    let mut cursor = start;
-    while cursor <= end {
-        if !existing.contains(&cursor) {
-            let utc = cursor.and_utc();
-            let (state, level) = charging_state_with_level(utc, "default");
-            let blob = json!({
-                "source_id": source_id,
-                "battery_id": "default",
-                "state": state,
-                "level": level,
-                "timestamp_utc": utc.to_rfc3339(),
-                "seeded": true,
-            })
-            .to_string();
-            batch.push(NewReading {
-                source_id,
-                timestamp: Some(cursor),
-                data: blob,
-                quality_flags: Some(0),
-            });
-        }
-        cursor += interval;
-    }
-
-    let to_write = batch.len();
-    if to_write == 0 {
+/// Print a one-line summary of a seed run.
+fn report_seed(kind: &str, site_id: i32, outcome: &neems_data::SeedOutcome) {
+    if outcome.written == 0 {
         println!(
-            "Source '{}' (ID {}) already has all {} slots seeded — nothing to do.",
-            source_name, source_id, total_slots
+            "Source '{}' (ID {}) already has all {} {} slots seeded — nothing to do.",
+            outcome.source_name, outcome.source_id, outcome.total_slots, kind
         );
-        return Ok(());
-    }
-
-    // Insert in chunks so SQLite doesn't choke on a giant single statement.
-    for chunk in batch.chunks(500) {
-        insert_readings_batch(conn, chunk.to_vec())?;
-    }
-
-    println!(
-        "Seeded {} new SoC readings ({} already present) into source '{}' (ID {}) for site {}.",
-        to_write,
-        total_slots - to_write,
-        source_name,
-        source_id,
-        args.site_id
-    );
-    Ok(())
-}
-
-/// Deterministic demo alarm state for a given instant.
-///
-/// Each tuple is `(alarm_num, period_minutes, active_minutes, phase_minutes)`:
-/// the alarm is active when the time-of-window position is within the first
-/// `active_minutes` of each `period_minutes` cycle. The chosen alarms span
-/// several zones and severities so the FDNY timeline has variety, and the
-/// long periods keep transitions sparse (a handful per alarm per week) rather
-/// than flapping every sample.
-fn seeded_alarm_flags(utc: chrono::DateTime<Utc>) -> AlarmFlags {
-    const PATTERN: &[(u16, i64, i64, i64)] = &[
-        (1, 1440, 90, 0),       // loss_fiber (L3) — ~daily, 90 min
-        (203, 2880, 180, 600),  // meter_loss_of_comms (L5) — every 2 days, 3 h
-        (301, 720, 60, 200),    // t1_temp_alarm (L4) — twice daily, 1 h
-        (104, 4320, 240, 1000), // estop (L2, critical) — every 3 days, 4 h
-        (7, 5760, 30, 2500),    // intruder_detected (L5) — every 4 days, 30 min
-    ];
-    let t_min = utc.timestamp() / 60;
-    let mut flags = AlarmFlags::default();
-    for &(num, period, active, phase) in PATTERN {
-        let pos = ((t_min - phase) % period + period) % period;
-        if pos < active {
-            flags.set_alarm_num(num, true);
-        }
-    }
-    flags
-}
-
-/// Backfill plausible past alarm readings for the given site.
-///
-/// Idempotent in the same way as [`seed_soc_history`]: existing reading
-/// timestamps for the source are skipped, so re-running only fills gaps.
-fn seed_alarm_history(
-    conn: &mut diesel::SqliteConnection,
-    args: SeedAlarmHistoryArgs,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
-    use diesel::prelude::*;
-    use neems_data::schema::{readings, sources};
-
-    if args.interval_minutes == 0 {
-        return Err("--interval-minutes must be > 0".into());
-    }
-
-    // Ensure an alarm_status source exists for this site. Reuse the existing
-    // one if present; otherwise create a deterministic name so re-runs find
-    // the same row.
-    let existing_source: Option<(Option<i32>, String)> = sources::table
-        .filter(sources::site_id.eq(args.site_id))
-        .filter(sources::test_type.eq("alarm_status"))
-        .select((sources::id, sources::name))
-        .first(conn)
-        .optional()?;
-
-    let (source_id, source_name) = match existing_source {
-        Some((Some(id), name)) => (id, name),
-        Some((None, name)) => {
-            return Err(format!("source '{}' has NULL id (corrupt row?)", name).into());
-        }
-        None => {
-            let name = format!("alarm_history_site_{}", args.site_id);
-            let new_source = NewSource {
-                name: name.clone(),
-                description: Some(format!("Demo alarm history for site {} (seeded)", args.site_id)),
-                active: Some(false), // seed-only; not polled live
-                interval_seconds: Some((args.interval_minutes as i32) * 60),
-                test_type: Some("alarm_status".to_string()),
-                arguments: Some("{}".to_string()),
-                site_id: Some(args.site_id),
-                company_id: None,
-            };
-            let created = create_source(conn, new_source)?;
-            let id = created.id.ok_or("create_source returned a row with no id")?;
-            println!("Created source '{}' (ID {})", created.name, id);
-            (id, created.name)
-        }
-    };
-
-    // Build the slot grid (oldest → newest, top of the minute), snapping the
-    // end to the most recent slot boundary so re-runs hit the same timestamps.
-    let interval = Duration::minutes(args.interval_minutes as i64);
-    let end = {
-        let now = Utc::now().naive_utc();
-        let secs = now.and_utc().timestamp();
-        let slot = interval.num_seconds();
-        let snapped = secs - (secs % slot);
-        chrono::DateTime::from_timestamp(snapped, 0)
-            .ok_or("failed to snap end timestamp")?
-            .naive_utc()
-    };
-    let start = end - Duration::days(args.days as i64);
-    let total_slots = ((end - start).num_seconds() / interval.num_seconds()) as usize + 1;
-
-    // Idempotency: pull existing timestamps in the window and skip them.
-    let existing: std::collections::HashSet<NaiveDateTime> = readings::table
-        .filter(readings::source_id.eq(source_id))
-        .filter(readings::timestamp.ge(start))
-        .filter(readings::timestamp.le(end))
-        .select(readings::timestamp)
-        .load::<NaiveDateTime>(conn)?
-        .into_iter()
-        .collect();
-
-    let mut batch: Vec<NewReading> = Vec::new();
-    let mut cursor = start;
-    while cursor <= end {
-        if !existing.contains(&cursor) {
-            let utc = cursor.and_utc();
-            let registers = seeded_alarm_flags(utc).to_registers();
-            let blob = json!({
-                "source_id": source_id,
-                "alarm_registers": registers.to_vec(),
-                "timestamp_utc": utc.to_rfc3339(),
-                "seeded": true,
-            })
-            .to_string();
-            batch.push(NewReading {
-                source_id,
-                timestamp: Some(cursor),
-                data: blob,
-                quality_flags: Some(0),
-            });
-        }
-        cursor += interval;
-    }
-
-    let to_write = batch.len();
-    if to_write == 0 {
+    } else {
         println!(
-            "Source '{}' (ID {}) already has all {} slots seeded — nothing to do.",
-            source_name, source_id, total_slots
+            "Seeded {} new {} readings ({} already present) into source '{}' (ID {}) for site {}.",
+            outcome.written,
+            kind,
+            outcome.already_present,
+            outcome.source_name,
+            outcome.source_id,
+            site_id
         );
-        return Ok(());
     }
-
-    // Insert in chunks so SQLite doesn't choke on a giant single statement.
-    for chunk in batch.chunks(500) {
-        insert_readings_batch(conn, chunk.to_vec())?;
-    }
-
-    println!(
-        "Seeded {} new alarm readings ({} already present) into source '{}' (ID {}) for site {}.",
-        to_write,
-        total_slots - to_write,
-        source_name,
-        source_id,
-        args.site_id
-    );
-    Ok(())
 }

--- a/neems-data/src/seed.rs
+++ b/neems-data/src/seed.rs
@@ -1,0 +1,232 @@
+//! Generation of plausible historical readings (SoC + alarms) for demos.
+//!
+//! This lives in the library (rather than the `neems-data` binary) so it is
+//! shared by both the `seed-soc-history` / `seed-alarm-history` CLI commands
+//! and the neems-api demo endpoint — the two therefore produce byte-identical
+//! data.
+//!
+//! Both seeders are idempotent: existing reading timestamps for the source are
+//! collected up-front and only missing slots are written, so re-running only
+//! fills gaps.
+
+use std::{collections::HashSet, error::Error};
+
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+use diesel::prelude::*;
+use serde_json::json;
+
+use crate::{
+    NewReading, NewSource,
+    collectors::data_sources::charging_state_with_level,
+    create_source, insert_readings_batch,
+    rtac::state::AlarmFlags,
+    schema::{readings, sources},
+};
+
+/// Summary of a single seed run.
+#[derive(Debug, Clone)]
+pub struct SeedOutcome {
+    pub source_id: i32,
+    pub source_name: String,
+    /// New readings actually written this run.
+    pub written: usize,
+    /// Slots skipped because a reading already existed at that timestamp.
+    pub already_present: usize,
+    /// Total slots spanned by the window (written + already_present).
+    pub total_slots: usize,
+}
+
+/// Deterministic demo alarm state for a given instant.
+///
+/// Each tuple is `(alarm_num, period_minutes, active_minutes, phase_minutes)`:
+/// the alarm is active when the time-of-window position is within the first
+/// `active_minutes` of each `period_minutes` cycle. The chosen alarms span
+/// several zones and severities so the FDNY timeline has variety, and the
+/// long periods keep transitions sparse (a handful per alarm per week) rather
+/// than flapping every sample.
+pub fn seeded_alarm_flags(utc: DateTime<Utc>) -> AlarmFlags {
+    const PATTERN: &[(u16, i64, i64, i64)] = &[
+        (1, 1440, 90, 0),       // loss_fiber (L3) — ~daily, 90 min
+        (203, 2880, 180, 600),  // meter_loss_of_comms (L5) — every 2 days, 3 h
+        (301, 720, 60, 200),    // t1_temp_alarm (L4) — twice daily, 1 h
+        (104, 4320, 240, 1000), // estop (L2, critical) — every 3 days, 4 h
+        (7, 5760, 30, 2500),    // intruder_detected (L5) — every 4 days, 30 min
+    ];
+    let t_min = utc.timestamp() / 60;
+    let mut flags = AlarmFlags::default();
+    for &(num, period, active, phase) in PATTERN {
+        let pos = ((t_min - phase) % period + period) % period;
+        if pos < active {
+            flags.set_alarm_num(num, true);
+        }
+    }
+    flags
+}
+
+/// Shared backfill loop: ensures a seed-only source exists for the site,
+/// builds an epoch-aligned slot grid over the last `days`, and writes a
+/// reading for each missing slot using `make_blob` to render the JSON data.
+fn seed_history<F>(
+    conn: &mut SqliteConnection,
+    site_id: i32,
+    days: u32,
+    interval_minutes: u32,
+    test_type: &str,
+    name_prefix: &str,
+    description_kind: &str,
+    make_blob: F,
+) -> Result<SeedOutcome, Box<dyn Error + Send + Sync>>
+where
+    F: Fn(i32, DateTime<Utc>) -> String,
+{
+    if interval_minutes == 0 {
+        return Err("interval_minutes must be > 0".into());
+    }
+
+    // Ensure a source exists for this site/test_type. Reuse the existing one if
+    // present; otherwise create a deterministic name so re-runs find the same
+    // row.
+    let existing_source: Option<(Option<i32>, String)> = sources::table
+        .filter(sources::site_id.eq(site_id))
+        .filter(sources::test_type.eq(test_type))
+        .select((sources::id, sources::name))
+        .first(conn)
+        .optional()?;
+
+    let (source_id, source_name) = match existing_source {
+        Some((Some(id), name)) => (id, name),
+        Some((None, name)) => {
+            return Err(format!("source '{}' has NULL id (corrupt row?)", name).into());
+        }
+        None => {
+            let name = format!("{}_site_{}", name_prefix, site_id);
+            let new_source = NewSource {
+                name: name.clone(),
+                description: Some(format!(
+                    "Demo {} for site {} (seeded)",
+                    description_kind, site_id
+                )),
+                active: Some(false), // seed-only; not polled live
+                interval_seconds: Some((interval_minutes as i32) * 60),
+                test_type: Some(test_type.to_string()),
+                arguments: Some("{}".to_string()),
+                site_id: Some(site_id),
+                company_id: None,
+            };
+            let created = create_source(conn, new_source)?;
+            let id = created.id.ok_or("create_source returned a row with no id")?;
+            (id, created.name)
+        }
+    };
+
+    // Build the slot grid (oldest → newest, top of the minute), snapping the
+    // end to the most recent slot boundary so re-runs hit the same timestamps.
+    let interval = Duration::minutes(interval_minutes as i64);
+    let end = {
+        let secs = Utc::now().timestamp();
+        let slot = interval.num_seconds();
+        let snapped = secs - (secs % slot);
+        DateTime::from_timestamp(snapped, 0)
+            .ok_or("failed to snap end timestamp")?
+            .naive_utc()
+    };
+    let start = end - Duration::days(days as i64);
+    // Inclusive on both endpoints, so slot count is span/interval + 1.
+    let total_slots = ((end - start).num_seconds() / interval.num_seconds()) as usize + 1;
+
+    // Idempotency: pull existing timestamps in the window and skip them.
+    let existing: HashSet<NaiveDateTime> = readings::table
+        .filter(readings::source_id.eq(source_id))
+        .filter(readings::timestamp.ge(start))
+        .filter(readings::timestamp.le(end))
+        .select(readings::timestamp)
+        .load::<NaiveDateTime>(conn)?
+        .into_iter()
+        .collect();
+
+    let mut batch: Vec<NewReading> = Vec::new();
+    let mut cursor = start;
+    while cursor <= end {
+        if !existing.contains(&cursor) {
+            batch.push(NewReading {
+                source_id,
+                timestamp: Some(cursor),
+                data: make_blob(source_id, cursor.and_utc()),
+                quality_flags: Some(0),
+            });
+        }
+        cursor += interval;
+    }
+
+    let written = batch.len();
+    // Insert in chunks so SQLite doesn't choke on a giant single statement.
+    for chunk in batch.chunks(500) {
+        insert_readings_batch(conn, chunk.to_vec())?;
+    }
+
+    Ok(SeedOutcome {
+        source_id,
+        source_name,
+        written,
+        already_present: total_slots - written,
+        total_slots,
+    })
+}
+
+/// Backfill plausible past SoC readings for the given site.
+pub fn seed_soc_history(
+    conn: &mut SqliteConnection,
+    site_id: i32,
+    days: u32,
+    interval_minutes: u32,
+) -> Result<SeedOutcome, Box<dyn Error + Send + Sync>> {
+    seed_history(
+        conn,
+        site_id,
+        days,
+        interval_minutes,
+        "charging_state",
+        "soc_history",
+        "SoC history",
+        |source_id, utc| {
+            let (state, level) = charging_state_with_level(utc, "default");
+            json!({
+                "source_id": source_id,
+                "battery_id": "default",
+                "state": state,
+                "level": level,
+                "timestamp_utc": utc.to_rfc3339(),
+                "seeded": true,
+            })
+            .to_string()
+        },
+    )
+}
+
+/// Backfill plausible past alarm readings for the given site.
+pub fn seed_alarm_history(
+    conn: &mut SqliteConnection,
+    site_id: i32,
+    days: u32,
+    interval_minutes: u32,
+) -> Result<SeedOutcome, Box<dyn Error + Send + Sync>> {
+    seed_history(
+        conn,
+        site_id,
+        days,
+        interval_minutes,
+        "alarm_status",
+        "alarm_history",
+        "alarm history",
+        |source_id, utc| {
+            let registers = seeded_alarm_flags(utc).to_registers();
+            json!({
+                "source_id": source_id,
+                "alarm_registers": registers.to_vec(),
+                "timestamp_utc": utc.to_rfc3339(),
+                "seeded": true,
+            })
+            .to_string()
+        },
+    )
+}


### PR DESCRIPTION
Two demo-mode backend changes:

- RTAC follow is now OFF by default. The collector reads RTAC_ENABLED once at startup; previously it defaulted on, so a demo without RTAC hardware would try to follow an absent connection. Flip the default to off (enable explicitly with RTAC_ENABLED=1/true/yes/on).

- Add POST /api/1/Demo/InjectHistory (admin / newtown-admin / newtown-staff). It generates plausible multi-day SoC and alarm history for a site server-side rather than having the frontend write data. The SoC/alarm generators move from the neems-data binary into a shared neems_data::seed library module so the CLI seed-*-history commands and the new endpoint produce identical data; both remain idempotent (re-running only fills missing slots).

Bumps the @newtown-energy/types version for the new request/response types (InjectHistoryRequest/Response, SeedSummary).