### PR TITLE
Add self-contained demo CD (Actions build → GHCR → DO App)

### DIFF
--- a/.do/README.md
+++ b/.do/README.md
@@ -1,0 +1,44 @@
+# Demo deployment (DigitalOcean App Platform)
+
+This repo continuously deploys the public **demo API** to its own App — there is
+no coordinator repo. On merge to `main`, `.github/workflows/deploy.yml` builds
+and pushes `ghcr.io/newtown-energy/neems-api`, then rolls a new deployment that
+re-pulls `:latest`.
+
+The React front end is a **separate** App (`neems-react`) whose Caddy proxies
+`/api` here, so the browser sees one origin and the `SameSite=Lax` session
+cookie keeps working. Keep both Apps on one registrable domain — same-origin or
+sibling subdomains (`api.demo.x` / `app.demo.x`), never fully cross-site.
+
+## One-time setup
+
+1. **Make the `neems-api` GHCR package public** (GitHub → org **Packages** →
+   `neems-api` → **Package settings** → change visibility → **Public**). The
+   image is just compiled binaries of this public repo, so App Platform can then
+   pull it with **no credential — no PAT to create or rotate.** The package only
+   appears after the first image push (first merge to `main`).
+   *(Private alternative: keep it private and set `registry_credentials` in
+   `.do/app.yaml` — see the comment there. A PAT expires; public access does not.)*
+2. Create the App straight from the committed spec (it holds no secrets):
+   ```bash
+   doctl auth init          # paste your DigitalOcean API token
+   doctl apps create --spec .do/app.yaml
+   doctl apps list          # note the App id + the *.ondigitalocean.app URL
+   ```
+3. Set `NEEMS_DEFAULT_PASSWORD` as a SECRET on the App (dashboard) before you
+   share the URL. Because the SQLite DB is ephemeral, the superadmin is
+   recreated from `NEEMS_DEFAULT_EMAIL`/`NEEMS_DEFAULT_PASSWORD` on every deploy,
+   so the value takes effect on the next deploy.
+4. Add repo secrets so CI can deploy: `DIGITALOCEAN_ACCESS_TOKEN`, `DO_APP_ID`.
+
+After this, every merge to `main` publishes an image and redeploys the App.
+
+## Notes
+
+- Routine CD uses `doctl apps create-deployment`, which redeploys with the App's
+  **stored** config — so the committed spec's placeholder password is never
+  applied by CI (your dashboard-set secret stands).
+- To change the spec itself, edit `.do/app.yaml` and run
+  `doctl apps update <id> --spec .do/app.yaml` manually (re-set secrets after).
+- `instance_size_slug` in the spec is a starting guess; confirm a current value
+  with `doctl apps tier instance-size list`.

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,55 @@
+# DigitalOcean App Platform spec for the public NEEMS demo API.
+#
+# Self-contained: this repo builds its image and deploys THIS App (no
+# coordinator repo). The React front end is a separate App (neems-react) whose
+# Caddy reverse-proxies /api here, so the browser stays same-origin and the
+# SameSite=Lax session cookie keeps working. Keep both Apps on one registrable
+# domain (same-origin or sibling subdomains like api.demo.x / app.demo.x).
+#
+# Routine CD uses `doctl apps create-deployment` (re-pull :latest), so this
+# committed spec is the bootstrap template + reference. Set the real registry
+# credential and secrets on the App itself — never commit them (public repo).
+# See .do/README.md.
+
+name: neems-demo-api
+region: nyc
+
+services:
+  - name: api
+    image:
+      registry_type: GHCR
+      registry: newtown-energy
+      repository: neems-api
+      tag: latest
+      # The neems-api GHCR package is PUBLIC, so App Platform pulls it with no
+      # credential — nothing to create or rotate. If you make the package
+      # private instead, add a durable credential here:
+      #   registry_credentials: "<gh-user>:<read:packages PAT>"
+      # (App Platform stores it encrypted.) Note a PAT expires; public does not.
+    http_port: 8000
+    # Adjust to a current slug from `doctl apps tier instance-size list`.
+    instance_size_slug: apps-s-1vcpu-0.5gb
+    instance_count: 1
+    routes:
+      - path: /
+    health_check:
+      http_path: /api/1/status
+    envs:
+      - key: ROCKET_ADDRESS
+        value: "0.0.0.0"
+      - key: ROCKET_PORT
+        value: "8000"
+      - key: DATABASE_URL
+        value: sqlite:///app/data/neems-api.db
+      - key: SITE_DATABASE_URL
+        value: sqlite:///app/data/site-data.sqlite
+      - key: NEEMS_DEFAULT_EMAIL
+        value: admin@example.com
+      # (NEEMS_DEFAULT_SITE / NEEMS_DEFAULT_COMPANY are read only by neems-data,
+      # which the demo doesn't run, so they're omitted here.)
+      # Set as a SECRET on the App (dashboard). Left as a placeholder here so a
+      # stray `doctl apps update --spec` can't reset it — routine CD uses
+      # create-deployment and never re-applies this spec.
+      - key: NEEMS_DEFAULT_PASSWORD
+        type: SECRET
+        value: REPLACE_ME

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the build context small and reproducible. target/ especially can be
+# many GB on a dev machine and must not leak host artifacts into the image.
+# NOTE: .git is intentionally NOT ignored — neems-api's build.rs uses the
+# `built` crate (git2) to embed GIT_COMMIT_HASH, surfaced at /api/1/status.
+# Without .git in the context the deployed commit would report as null.
+target/
+local-types/
+*.db
+*.sqlite
+*.sqlite-*
+**/*.swp
+.DS_Store

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,86 @@
+name: Demo CD
+
+# Self-contained continuous deployment for this repo's public demo API App on
+# DigitalOcean App Platform. No coordinator repo — neems-core owns and deploys
+# its own App.
+#
+#   - pull request      -> build the image as a check (no push, no deploy)
+#   - merge to main      -> push ghcr.io/newtown-energy/neems-api, then roll a
+#                           new deployment of the demo API App (re-pulls :latest)
+#
+# The demo App is the ONLY environment fed by CI. Production sites are
+# air-gapped, behind a VPN, and updated by hand — never touched here.
+#
+# Required repo secrets (beyond the automatic GITHUB_TOKEN, which pushes to GHCR):
+#   DIGITALOCEAN_ACCESS_TOKEN - DO API token (app read/write)
+#   DO_APP_ID                 - id of the demo API App (`doctl apps list`)
+# One-time setup: see .do/README.md.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  pull_request:
+    paths:
+      - 'Dockerfile.demo'
+      - '.dockerignore'
+      - 'neems-*/**'
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.do/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/newtown-energy/neems-api
+
+jobs:
+  build:
+    name: Build image${{ github.event_name == 'pull_request' && ' (check)' || ' and push' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (and push on main)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.demo
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy demo API App
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      # Roll a new deployment that re-pulls the :latest image. Uses the App's
+      # stored config, so committed placeholder secrets/creds are never applied.
+      - name: Roll a new deployment
+        run: doctl apps create-deployment "${{ secrets.DO_APP_ID }}" --wait

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -1,0 +1,71 @@
+# Demo image for the NEEMS backend (production/release build).
+#
+# Built and pushed to GHCR by GitHub Actions (.github/workflows/deploy.yml) on
+# merge to main (and built as a check on PRs); DigitalOcean App Platform pulls
+# the image and deploys it. The demo runs neems-api only, so we build neems-api
+# + neems-admin (for seeding/admin) — not the data aggregator or RTAC simulator.
+#
+# cargo-chef splits dependency compilation into its own layer so the GitHub
+# Actions build cache (cache-to: gha) makes source-only rebuilds fast (deps are
+# recompiled only when Cargo.toml / Cargo.lock change).
+
+# ---- chef: tool base --------------------------------------------------------
+FROM rustlang/rust:nightly-bookworm AS chef
+# Install cargo-chef with the image's default nightly (before the toolchain is
+# pinned) — the chef binary just orchestrates; the pinned toolchain below does
+# the actual compiling.
+RUN cargo install cargo-chef --locked
+WORKDIR /usr/src/app
+
+# ---- planner: capture the dependency recipe ---------------------------------
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ---- builder: cook deps (cached), then build our binaries -------------------
+FROM chef AS builder
+# diesel links against the system libsqlite3 at build time.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+# Pin the toolchain BEFORE cooking so the cooked deps match the final build
+# (a toolchain mismatch would silently recompile everything).
+COPY rust-toolchain.toml .
+RUN rustup show
+# Cook dependencies — cached until recipe.json (i.e. Cargo.toml/lock) changes.
+COPY --from=planner /usr/src/app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build our binaries against the pre-built deps.
+COPY . .
+RUN cargo build --release --bin neems-api --bin neems-admin
+
+# ---- runtime ----------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libsqlite3-0 \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Run as a non-root system user.
+RUN useradd --system --create-home --home-dir /app neems
+WORKDIR /app
+
+# Data dir (SQLite lives here; ephemeral on App Platform) and an empty static
+# dir so Rocket's FileServer mount has a valid path. In the demo the React app
+# is served by the neems-web (Caddy) container, not by Rocket.
+RUN mkdir -p /app/data /app/static && chown -R neems:neems /app
+
+COPY --from=builder /usr/src/app/target/release/neems-api   /usr/local/bin/
+COPY --from=builder /usr/src/app/target/release/neems-admin /usr/local/bin/
+
+# Migrations are embedded and applied on startup (neems-api/src/lib.rs attaches
+# run_migrations_fairing()), so no diesel_cli is needed at runtime.
+ENV ROCKET_ADDRESS=0.0.0.0 \
+    ROCKET_PORT=8000 \
+    NEEMS_STATIC_DIR=/app/static
+
+USER neems
+EXPOSE 8000
+
+CMD ["neems-api"]

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,63 @@
+# Environment variables
+
+Canonical reference for every environment variable the NEEMS backend reads.
+This is the single source of truth; compose files, the demo App spec, and
+deploy scripts should follow the conventions here rather than inventing their
+own spellings.
+
+## Conventions
+
+- **SQLite URLs** — for containers and deployments, prefer
+  `sqlite://<absolute-path>` (e.g. `sqlite:///app/data/neems-api.db` — three
+  slashes: `sqlite://` + `/app/...`). `neems-api` passes the value straight to
+  Rocket's database pool; `neems-data` normalizes a leading `sqlite://` (see
+  `neems-data/src/lib.rs`), so both accept this form. Bare/relative forms like
+  `sqlite:neems-api.db` also work and are still used in local dev (see
+  `env.example` and the per-crate dev Dockerfiles); the `sqlite://<abspath>`
+  form is the recommended convention for the demo/deploy specs here, not a hard
+  requirement everywhere.
+- **Rocket's own settings** use the `ROCKET_` prefix and can also come from
+  `Rocket.toml`; env wins.
+- Values marked **required** have no default — the process fails fast if unset.
+
+## neems-api
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `DATABASE_URL` | yes | — | Main app DB. In containers: `sqlite:///app/data/neems-api.db`. Also used by diesel for migrations. |
+| `SITE_DATABASE_URL` | yes | — | Site/time-series DB shared with `neems-data`. In containers: `sqlite:///app/data/site-data.sqlite`. |
+| `NEEMS_STATIC_DIR` | no | `static` | Directory Rocket serves at `/`. In the demo the SPA is served by Caddy, so this points at an empty dir. |
+| `ROCKET_ADDRESS` | no | `127.0.0.1` | Listen address. Set `0.0.0.0` in containers. |
+| `ROCKET_PORT` | no | `8000` | Listen port. |
+| `ROCKET_SECRET_KEY` | no | — | Not currently used: Rocket's `secrets` feature is off and the session cookie is a plain cookie (a server-side token validated against the DB). Only becomes relevant if the `secrets` feature / private cookies are later enabled. |
+| `NEEMS_DEFAULT_EMAIL` | no | `superadmin@example.com` | Bootstrap superadmin created on first boot. |
+| `NEEMS_DEFAULT_PASSWORD` | no | `admin` | Bootstrap superadmin password. **Override in any public deployment.** |
+| `NEEMS_TS_OUTPUT_DIR` | no | (unset) | Dev/CI only: where generated TypeScript bindings are written. |
+
+## neems-data
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `SITE_DATABASE_URL` | no | `site-data.sqlite` | Site DB (same file as neems-api's `SITE_DATABASE_URL`). Canonical: `sqlite:///app/data/site-data.sqlite`. |
+| `NEEMS_API_URL` | no | `http://neems-api:8000` | Base URL of neems-api, polled for the active schedule command. |
+| `NEEMS_API_EMAIL` | no | falls back to `NEEMS_DEFAULT_EMAIL` | Credentials for that API. |
+| `NEEMS_API_PASSWORD` | no | falls back to `NEEMS_DEFAULT_PASSWORD` | Credentials for that API. |
+| `NEEMS_DEFAULT_SITE` | no | `1` | Site id the collector attaches readings to. |
+| `NEEMS_DEFAULT_COMPANY` | no | `1` | Company id for the collector. |
+| `RTAC_ENABLED` | no | `false` | Enable the closed-loop RTAC collector. Truthy values: `1`, `true`, `yes`, `on`. |
+| `RTAC_ADDRESS` | no | built-in (`host:port`) | RTAC Modbus endpoint. In the dev stack this is `neems-rtac-sim:502`. Ignored when `RTAC_ENABLED` is off. |
+| `RTAC_SLAVE_ID` | no | built-in | Modbus slave/unit id. Ignored when `RTAC_ENABLED` is off. |
+
+## Reserved / not yet wired
+
+| Variable | Notes |
+| --- | --- |
+| `ENABLE_TOTP` | Present in `env.example` but not currently read by any code. |
+
+## Where each deployment sets these
+
+- **Dev** (`devenv/docker-compose.yml`) — full stack incl. `neems-data` + the
+  RTAC simulator; `RTAC_ENABLED=1`, `RTAC_ADDRESS=neems-rtac-sim:502`.
+- **Public demo** (`neems-demo` App spec) — `neems-api` only. No `neems-data`,
+  no RTAC; demo data comes from the Demo API / seeding. SQLite lives on the
+  container's ephemeral disk and resets on each deploy.

--- a/env.example
+++ b/env.example
@@ -1,5 +1,9 @@
+# Canonical reference for every backend env var (names, defaults, and the
+# sqlite:// URL convention): see docs/environment.md.
+
 # This is the envar that diesel uses to manage migrations. It should match the
-# one in Rocket.toml
+# one in Rocket.toml. In containers use an absolute sqlite:// URL, e.g.
+# sqlite:///app/data/neems-api.db (see docs/environment.md).
 DATABASE_URL=sqlite:neems-api.db
 
 # This is not used by anything yet


### PR DESCRIPTION
Sets up **self-contained continuous deployment** for this repo's public demo API on DigitalOcean App Platform — no coordinator repo, and **no DigitalOcean GitHub App** (installing it needs org admin we don't have). GitHub Actions builds the image; DO pulls and deploys.

**Model:** on merge to `main`, Actions builds `Dockerfile.demo` and pushes `ghcr.io/newtown-energy/neems-api:latest` (public), then `doctl apps create-deployment` rolls the DO App (`image` source, re-pulling `:latest`).

**What's here:**
- **`Dockerfile.demo`** — release build of `neems-api` + `neems-admin` (the demo runs `neems-api` only), layered with **cargo-chef** so dependency compilation is cached (`cache-to: gha`) → fast source-only rebuilds.
- **`.github/workflows/deploy.yml`** — on PRs builds the image as a **check** (no push); on merge to `main` pushes to GHCR then `doctl apps create-deployment`.
- **`.do/app.yaml`** — the demo API App (single public service, ephemeral SQLite), `image: GHCR` source; the package is public, so no pull credential.
- **`.do/README.md`** — one-time setup (make the image public, create the App, secrets).
- **`docs/environment.md`** — canonical env-var reference (`sqlite://<abspath>`).

**Topology:** the React front end is a separate App (`neems-react`) whose Caddy proxies `/api` here, so the browser stays same-origin (the `SameSite=Lax` cookie is unaffected). Keep both Apps on one registrable domain.

**Required repo secrets:** `DIGITALOCEAN_ACCESS_TOKEN`, `DO_APP_ID` (+ the automatic `GITHUB_TOKEN` for GHCR push).

The demo App is the only environment fed by CI; production sites are air-gapped and updated by hand.

Verified: image builds/runs locally (non-root); workflow + App spec YAML validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
