### PR TITLE
Rename DO_APP_ID secret to DIGITALOCEAN_APP_ID

### DIFF
--- a/.do/README.md
+++ b/.do/README.md
@@ -29,7 +29,7 @@ sibling subdomains (`api.demo.x` / `app.demo.x`), never fully cross-site.
    share the URL. Because the SQLite DB is ephemeral, the superadmin is
    recreated from `NEEMS_DEFAULT_EMAIL`/`NEEMS_DEFAULT_PASSWORD` on every deploy,
    so the value takes effect on the next deploy.
-4. Add repo secrets so CI can deploy: `DIGITALOCEAN_ACCESS_TOKEN`, `DO_APP_ID`.
+4. Add repo secrets so CI can deploy: `DIGITALOCEAN_ACCESS_TOKEN`, `DIGITALOCEAN_APP_ID`.
 
 After this, every merge to `main` publishes an image and redeploys the App.
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ name: Demo CD
 #
 # Required repo secrets (beyond the automatic GITHUB_TOKEN, which pushes to GHCR):
 #   DIGITALOCEAN_ACCESS_TOKEN - DO API token (app read/write)
-#   DO_APP_ID                 - id of the demo API App (`doctl apps list`)
+#   DIGITALOCEAN_APP_ID       - id of the demo API App (`doctl apps list`)
 # One-time setup: see .do/README.md.
 
 on:
@@ -83,4 +83,4 @@ jobs:
       # Roll a new deployment that re-pulls the :latest image. Uses the App's
       # stored config, so committed placeholder secrets/creds are never applied.
       - name: Roll a new deployment
-        run: doctl apps create-deployment "${{ secrets.DO_APP_ID }}" --wait
+        run: doctl apps create-deployment "${{ secrets.DIGITALOCEAN_APP_ID }}" --wait

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,5 +82,16 @@ jobs:
 
       # Roll a new deployment that re-pulls the :latest image. Uses the App's
       # stored config, so committed placeholder secrets/creds are never applied.
+      #
+      # An unset secret interpolates to an empty string rather than failing, so
+      # a missing APP_ID would otherwise reach the API as `/v2/apps//deployments`
+      # and come back as an opaque 405. Check it first and say what is wrong.
       - name: Roll a new deployment
-        run: doctl apps create-deployment "${{ secrets.DIGITALOCEAN_APP_ID }}" --wait
+        env:
+          APP_ID: ${{ secrets.DIGITALOCEAN_APP_ID }}
+        run: |
+          if [ -z "$APP_ID" ]; then
+            echo "::error::DIGITALOCEAN_APP_ID is not set. Add it as a repo secret (see .do/README.md)."
+            exit 1
+          fi
+          doctl apps create-deployment "$APP_ID" --wait


### PR DESCRIPTION
Standardizes the demo-deploy secret names: `DO_APP_ID` → `DIGITALOCEAN_APP_ID`, so it matches `DIGITALOCEAN_ACCESS_TOKEN` (both `DIGITALOCEAN_` prefix). Keeps the token name unchanged so it doesn't need regenerating.

Touches `.github/workflows/deploy.yml` (the `create-deployment` step + the required-secrets comment) and `.do/README.md`.

**Action after merge:** add a repo secret `DIGITALOCEAN_APP_ID` with the App id, and delete the old `DO_APP_ID`.

## Also: fail loudly when the secret is missing

This rename went unnoticed on `main` because GitHub interpolates an **unset secret
to an empty string** rather than failing. `doctl` was handed `""`, built
`POST /v2/apps//deployments`, and DigitalOcean answered an opaque `405` -- with the
image build having already succeeded, so only the deploy step went red.

The deploy step now checks the value first and fails with a message naming the
secret. It also passes it via `env:` instead of interpolating it directly into the
shell script, which keeps the value out of the generated script body.

Validated with `actionlint` (which also shellchecks `run:` blocks) -- clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
