### PR TITLE
Group Dependabot GitHub Action bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    # One PR per week for all Action bumps rather than one PR per Action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Groups all `github-actions` updates into a single weekly Dependabot PR instead of one PR per Action.

The last cycle produced four separate PRs (#81–#84) for four one-line version bumps, each with its own review and full CI run. Reviewing them individually costs more than the change is worth.

```yaml
    groups:
      github-actions:
        patterns:
          - "*"
```

Dependabot still opens a separate PR for anything it cannot group, so nothing is silently dropped — grouping changes how updates are batched, not whether they are surfaced.

Schedule is unchanged (weekly, Monday 09:00).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MBhtRfWpUbJAY1rH9Euwf
