### PR TITLE
Stop the dev target volume growing without bound

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,42 @@ endpoint and the React dashboard.
 - Disabled by default so the system doesn't follow a (possibly absent) RTAC
   connection. Enable it with `RTAC_ENABLED=1` (or `true`/`yes`/`on`).
 
+## The shared `target/` volume
+
+`neems-api`, `neems-data`, and `neems-rtac-sim` all mount the same
+`target-cache` volume at `/usr/src/app/target`. Cargo never garbage-collects
+`target/`, so without help that volume grows without bound — it reached 173 GB
+and filled the Docker VM's disk (issue #94).
+
+**Check it with `./bin/dosh disk`. Prune it with `./bin/dosh sweep`.** The
+neems-api container does the same sweep on start and every 6 hours after.
+
+Reference numbers, so a future change can be judged against them: one clean
+build of everything — every bin, every test binary, single fingerprint, no
+incremental — is about **5.7 GB**. The default ceiling is 10 GB.
+
+Four things hold that line, and each is easy to undo by accident:
+
+- **Never set `RUSTFLAGS` for a one-off command.** Debug info is capped in
+  `[profile.dev]` in the workspace `Cargo.toml`. `RUSTFLAGS` is part of a
+  build's fingerprint, so setting it for some invocations and not others makes
+  cargo build and keep a second complete set of artifacts for the same code.
+  Two `libneems_api` rlibs, 300 MB each, is what that looked like.
+- **`cargo sweep --maxsize` enforces the ceiling**, oldest artifacts first. A
+  ceiling rather than an age cutoff, because only a ceiling answers "this will
+  never exceed N".
+- **`target/debug/incremental` is bounded separately, and first.** cargo-sweep
+  will not touch that directory but does count it toward the total, so a large
+  incremental cache makes cargo-sweep delete everything it *can* reach to
+  compensate — a full rebuild for nothing. Keep the incremental prune ahead of
+  the sweep.
+- `fast_test_rocket()` sweeps per-test database copies older than an hour, and
+  `bin/create-golden-db.sh` removes superseded golden databases.
+
+Tunable via environment (defaults in `neems-api/docker-entrypoint.sh`, set in
+`devenv/docker-compose.yml`): `CARGO_TARGET_MAXSIZE`,
+`CARGO_TARGET_SWEEP_INTERVAL`, `CARGO_INCREMENTAL_MAXSIZE_MB`.
+
 ## Development Workflow
 
 ### Linting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,19 @@ signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 tokio = { version = "1.46.1", features = ["full", "macros", "rt-multi-thread"] }
 ts-rs  = { version = "10.1", features = ["chrono-impl"] }
 uuid = { version = "1.17.0", features = ["v4", "serde"] }
+
+[profile.dev]
+# Line tables only, rather than the full DWARF type tree.
+#
+# This lives here rather than in RUSTFLAGS so that every cargo invocation
+# agrees on it. RUSTFLAGS is part of a build's fingerprint, so when only some
+# invocations set it — as was the case when the neems-api entrypoint exported
+# it and a one-off `docker compose run ... cargo test` did not — cargo builds
+# and keeps a *second* complete set of artifacts for the same code. See
+# issue #94.
+#
+# The original reason for reducing it stands: full debug info (debuginfo = 2)
+# was tipping aarch64 debug links over ~1.5 GB each, and with cargo running
+# several test-binary links in parallel, ld was getting OOM-killed (signal 9).
+# Line tables keep panics pointing at real source lines.
+debug = 1

--- a/bin/create-golden-db.sh
+++ b/bin/create-golden-db.sh
@@ -256,6 +256,14 @@ if [ -n "$DEVICE_SITE2_ID" ]; then
     $NEEMS_ADMIN_BIN device add --name "SEL-735B" --type "Meter" --model "SEL-735" --serial "TEST003" --company "$DEVICE_COMPANY2_ID" --site "$DEVICE_SITE2_ID"
 fi
 
+# Only the newest golden database is ever used (see the `ls -t | head -1` at the
+# top of this script and get_golden_db_path() in orm/testing.rs), so the older
+# ones are dead weight in the shared target volume. See issue #94.
+ls -t "$TARGET_DIR"/golden_test_*.db 2>/dev/null | tail -n +2 | while read -r old_db; do
+    echo "Removing superseded golden database: $(basename "$old_db")"
+    rm -f "$old_db"
+done
+
 echo "Golden database v$VERSION_TIMESTAMP created successfully at: $GOLDEN_DB_PATH"
 echo "You can now run tests with: cargo test --features test-staging"
 echo ""

--- a/bin/dosh
+++ b/bin/dosh
@@ -177,7 +177,10 @@ sweep() {
 
     cargo sweep --maxsize "$maxsize" "${BASEDIR}" || echo "cargo sweep failed"
 
-    rm -f "$target"/test_db_*.db 2>/dev/null || true
+    # Only test databases untouched for an hour, matching STALE_TEST_DB_AGE in
+    # orm/testing.rs. A test run in another shell owns its copies, and pulling
+    # one out from under it would be far worse than leaving a stray file.
+    find "$target" -maxdepth 1 -name 'test_db_*.db' -mmin +60 -delete 2>/dev/null || true
     echo "After:  $(du -sh "$target" 2>/dev/null | cut -f1)"
 }
 

--- a/bin/dosh
+++ b/bin/dosh
@@ -122,6 +122,65 @@ _install-cranelift() {
     fi
 }
 
+disk() {
+    # Report what the shared target/ volume is holding
+
+    local target="${BASEDIR}/target"
+    [ -d "$target" ] || { echo "No target/ directory at $target"; return 0; }
+
+    echo "target/ total: $(du -sh "$target" 2>/dev/null | cut -f1)"
+    # `|| true` throughout: dosh runs under `set -eo pipefail`, and a missing
+    # path or an unmatched glob would otherwise abort a read-only report.
+    { du -sh "$target"/debug/deps "$target"/debug/incremental "$target"/debug/build \
+        2>/dev/null || true; } | sort -rh || true
+    local strays=0
+    local f
+    for f in "$target"/test_db_*.db; do
+        [ -e "$f" ] && strays=$((strays + 1))
+    done
+    echo "leftover test databases: ${strays}"
+    echo
+    echo "Run './bin/dosh sweep' to prune. Cargo never does this on its own —"
+    echo "see the 'shared target/ volume' section in AGENTS.md."
+}
+
+sweep() {
+    # Prune the shared target/ volume down to a size ceiling
+    #
+    # Cargo never garbage-collects target/, which is how it reached 173 GB
+    # (issue #94). The neems-api container does this on a timer; this is the
+    # same thing on demand. Pass a size to override, e.g. './bin/dosh sweep 8GB'.
+
+    local maxsize="${1:-${CARGO_TARGET_MAXSIZE:-10GB}}"
+    local incremental_max_mb="${CARGO_INCREMENTAL_MAXSIZE_MB:-3072}"
+    local target="${BASEDIR}/target"
+
+    if ! command -v cargo-sweep >/dev/null 2>&1; then
+        echo "❌ cargo-sweep is not installed. Install it with:"
+        echo "     cargo install cargo-sweep    (or './bin/dosh depends')"
+        return 1
+    fi
+
+    echo "Before: $(du -sh "$target" 2>/dev/null | cut -f1)"
+
+    # Bound target/debug/incremental first and separately. cargo-sweep will not
+    # touch it but does count it, so leaving it large makes cargo-sweep delete
+    # everything it *can* reach to compensate — a full rebuild for nothing.
+    if [ -d "$target/debug/incremental" ]; then
+        local size_mb
+        size_mb=$(du -sm "$target/debug/incremental" 2>/dev/null | cut -f1)
+        if [ -n "$size_mb" ] && [ "$size_mb" -gt "$incremental_max_mb" ]; then
+            echo "Incremental cache is ${size_mb}MB (limit ${incremental_max_mb}MB), clearing it"
+            rm -rf "${target:?}/debug/incremental"/* 2>/dev/null || true
+        fi
+    fi
+
+    cargo sweep --maxsize "$maxsize" "${BASEDIR}" || echo "cargo sweep failed"
+
+    rm -f "$target"/test_db_*.db 2>/dev/null || true
+    echo "After:  $(du -sh "$target" 2>/dev/null | cut -f1)"
+}
+
 build() {
     # Build a dev bin
 
@@ -176,6 +235,10 @@ depends() {
 
   # We don't actually use machete in dosh, but it is useful generally
   which cargo-machete > /dev/null || ${CARGO} binstall --no-confirm cargo-machete
+
+  # Backs './bin/dosh sweep'. Cargo never garbage-collects target/, which is how
+  # it reached 173 GB (issue #94).
+  which cargo-sweep > /dev/null || ${CARGO} binstall --no-confirm cargo-sweep
 
   # We should probably change this to a binstall
   ${CARGO} nextest --version &> /dev/null || cargo install --locked cargo-nextest || { echo "Can't install nextest"; exit 1; }

--- a/neems-api/Dockerfile
+++ b/neems-api/Dockerfile
@@ -4,12 +4,15 @@ FROM rustlang/rust:nightly-bookworm
 # Install Rust tooling components (clippy, rustfmt, rust-src)
 RUN rustup component add clippy rustfmt rust-src
 
-# Install sqlite3, cargo-watch for live reload, and diesel_cli for migrations
+# Install sqlite3, cargo-watch for live reload, diesel_cli for migrations, and
+# cargo-sweep to keep the shared target volume from growing without bound
+# (see issue #94 and the entrypoint).
 RUN apt-get update && apt-get install -y \
     sqlite3 \
     libsqlite3-dev \
     && rm -rf /var/lib/apt/lists/* \
     && cargo install cargo-watch \
+    && cargo install cargo-sweep \
     && cargo install diesel_cli --no-default-features --features sqlite
 
 # Set working directory

--- a/neems-api/docker-entrypoint.sh
+++ b/neems-api/docker-entrypoint.sh
@@ -58,7 +58,15 @@ sweep_target() {
   fi
 
   # Test database copies from runs that died before their own sweep could run.
-  rm -f /usr/src/app/target/test_db_*.db 2>/dev/null || true
+  #
+  # Only ones untouched for an hour, matching STALE_TEST_DB_AGE in
+  # orm/testing.rs. A test run in progress owns its copies, and this sweep fires
+  # on a timer with no idea whether one is underway — `docker compose exec
+  # neems-api ... test` is how AGENTS.md says to run tests, so that overlap is
+  # routine rather than hypothetical. Deleting a database out from under a
+  # running test would be far worse than leaving a stray file.
+  find /usr/src/app/target -maxdepth 1 -name 'test_db_*.db' -mmin +60 -delete \
+    2>/dev/null || true
 }
 
 echo "Sweeping build artifacts down to ${CARGO_TARGET_MAXSIZE}..."

--- a/neems-api/docker-entrypoint.sh
+++ b/neems-api/docker-entrypoint.sh
@@ -1,13 +1,77 @@
 #!/bin/bash
 set -e
 
-# Cap debug info to line tables (debuginfo=1) so the linker's peak
-# memory during parallel test-binary links stays under the Docker VM
-# allocation. Full debug info (debuginfo=2) was tipping aarch64 debug
-# links over ~1.5 GB each — when cargo ran 3-4 in parallel ld would
-# get OOM-killed (signal 9). debuginfo=1 keeps line numbers (so panics
-# still point at real source lines) without the full DWARF type tree.
-export RUSTFLAGS="${RUSTFLAGS} -C debuginfo=1"
+# Debug info is capped to line tables in [profile.dev] in the workspace
+# Cargo.toml, not here. It used to be exported as RUSTFLAGS from this script,
+# which meant any cargo run another way — `docker compose run ... cargo test`,
+# say — had a different fingerprint and built a second full set of artifacts
+# into the same target volume. See issue #94.
+
+# --- Keep the shared target volume under a hard ceiling -----------------------
+#
+# Cargo never garbage-collects target/: every rebuild writes new hash-suffixed
+# artifacts and the old ones stay forever. With two cargo watch processes below,
+# ~20 integration test binaries that each statically link the whole workspace,
+# and three services sharing this volume, that reached 173 GB and filled the
+# Docker VM's disk (issue #94).
+#
+# A size ceiling rather than an age cutoff, because only a ceiling actually
+# answers "this will never take more than N". cargo-sweep removes oldest-first
+# until the target directory is under CARGO_TARGET_MAXSIZE.
+#
+# For reference: one clean build of this workspace — every bin and every test
+# binary, single fingerprint, no incremental — measures about 5.7 GB. The
+# default leaves room for that plus normal churn. Setting it below a full build
+# would just sweep away artifacts that are immediately rebuilt.
+CARGO_TARGET_MAXSIZE="${CARGO_TARGET_MAXSIZE:-10GB}"
+
+# How often to re-check. Sweeping only at startup is not enough: with
+# `restart: unless-stopped` a container can run for weeks between starts, which
+# is exactly how the volume got to 173 GB in the first place.
+CARGO_TARGET_SWEEP_INTERVAL="${CARGO_TARGET_SWEEP_INTERVAL:-21600}" # 6 hours
+
+# target/debug/incremental gets its own budget because cargo-sweep will not
+# touch it — verified with `--dry-run`, which reports zero paths there — while
+# still counting it toward the total. Left alone, a 6 GB incremental directory
+# under a 10 GB ceiling forces cargo-sweep to delete nearly every artifact it
+# *can* reach to compensate, which is a full rebuild for nothing.
+#
+# So bound it first and separately. It is a pure cache; cargo rebuilds it, and
+# the cost of dropping it is one slower compile.
+CARGO_INCREMENTAL_MAXSIZE_MB="${CARGO_INCREMENTAL_MAXSIZE_MB:-3072}" # 3 GB
+
+sweep_target() {
+  local incremental=/usr/src/app/target/debug/incremental
+
+  if [ -d "$incremental" ]; then
+    local size_mb
+    size_mb=$(du -sm "$incremental" 2>/dev/null | cut -f1)
+    if [ -n "$size_mb" ] && [ "$size_mb" -gt "$CARGO_INCREMENTAL_MAXSIZE_MB" ]; then
+      echo "Incremental cache is ${size_mb}MB (limit ${CARGO_INCREMENTAL_MAXSIZE_MB}MB), clearing it"
+      rm -rf "${incremental:?}"/* 2>/dev/null || true
+    fi
+  fi
+
+  if command -v cargo-sweep >/dev/null 2>&1; then
+    cargo sweep --maxsize "$CARGO_TARGET_MAXSIZE" /usr/src/app \
+      || echo "cargo sweep failed, continuing"
+  fi
+
+  # Test database copies from runs that died before their own sweep could run.
+  rm -f /usr/src/app/target/test_db_*.db 2>/dev/null || true
+}
+
+echo "Sweeping build artifacts down to ${CARGO_TARGET_MAXSIZE}..."
+sweep_target
+
+# Keep sweeping for the life of the container. Backgrounded before the `exec`
+# below, so it survives as its own process. Failure is never worth stopping the
+# container over, hence the guards above.
+(
+  while sleep "$CARGO_TARGET_SWEEP_INTERVAL"; do
+    sweep_target
+  done
+) &
 
 # Run database migrations
 echo "Running database migrations..."

--- a/neems-api/src/orm/testing.rs
+++ b/neems-api/src/orm/testing.rs
@@ -161,6 +161,52 @@ pub fn test_rocket() -> Rocket<Build> {
     crate::mount_api_routes(rocket)
 }
 
+/// How long a per-test database copy has to be untouched before it is taken to
+/// be a leftover rather than in use.
+///
+/// Generous on purpose: test binaries run in parallel, and deleting a copy out
+/// from under a running test would be far worse than leaving a stray file.
+const STALE_TEST_DB_AGE: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+/// Delete test database copies left behind by earlier runs.
+///
+/// Each `fast_test_rocket()` copies the golden database to its own file, and
+/// nothing owns that copy afterwards — the Rocket instance is handed to the
+/// caller and the file outlives it. 782 of them had accumulated before this
+/// existed (issue #94).
+///
+/// Sweeping on the way in rather than tracking ownership on the way out keeps
+/// this to one place instead of every call site, and is safe under parallel
+/// test binaries because only files older than [`STALE_TEST_DB_AGE`] are
+/// touched. Runs once per process; any error is ignored, since failing to tidy
+/// up is never a reason to fail a test.
+fn sweep_stale_test_dbs(dir: &std::path::Path) {
+    use std::sync::Once;
+    static SWEPT: Once = Once::new();
+
+    SWEPT.call_once(|| {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            if !name.starts_with("test_db_") || !name.ends_with(".db") {
+                continue;
+            }
+            let is_stale = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .and_then(|m| m.elapsed().map_err(std::io::Error::other))
+                .map(|age| age > STALE_TEST_DB_AGE)
+                .unwrap_or(false);
+            if is_stale {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    });
+}
+
 /// Creates a fast Rocket instance for testing by copying a pre-populated golden
 /// database. This is much faster than test_rocket() because it skips all the
 /// initialization fairings.
@@ -182,10 +228,9 @@ pub fn fast_test_rocket() -> Rocket<Build> {
 
     // Create a unique copy for this test in the same directory as the golden
     // database
-    let test_db_path = golden_db_path
-        .parent()
-        .expect("Golden DB should have a parent directory")
-        .join(format!("test_db_{}.db", Uuid::new_v4()));
+    let test_db_dir = golden_db_path.parent().expect("Golden DB should have a parent directory");
+    sweep_stale_test_dbs(test_db_dir);
+    let test_db_path = test_db_dir.join(format!("test_db_{}.db", Uuid::new_v4()));
 
     // Copy the golden database - this creates a brand new file with no existing
     // connections


### PR DESCRIPTION
Closes #94.

The `target-cache` volume shared by `neems-api`, `neems-data` and
`neems-rtac-sim` had reached **173 GB** and filled the Docker VM's disk — an
unrelated `cargo test` died with `ld: final link failed: No space left on
device`.

Cargo never garbage-collects `target/`. Measured before clearing it:

| Path | Size | Detail |
| --- | --- | --- |
| `target/debug/deps` | 100 GB | 58,750 files, oldest dated 2025-11-10 |
| `target/debug/incremental` | 58 GB | 1,152 directories |
| `target/test_db_*.db` | 181 MB | 782 leaked test databases |

**Nothing here changes what is built. It changes what is kept.**

## A ceiling, checked on a timer

`cargo sweep --maxsize` removes oldest-first until `target/` is under
`CARGO_TARGET_MAXSIZE` (default 10 GB). An age cutoff can't answer "this will
never exceed N"; a ceiling can.

It runs **on start and every six hours after**. Sweeping only at startup isn't
enough — with `restart: unless-stopped` a container can run for weeks between
starts, which is precisely how the volume got to 173 GB.

## The ordering that matters

`target/debug/incremental` is bounded **separately, and first**. cargo-sweep
won't touch that directory but does count it toward the total, so leaving it
alone backfires badly. Observed with a 10 GB ceiling and a 3.8 GB incremental
cache:

```
deps 15 GB → 648 KB          # everything sweepable deleted to compensate
incremental 3.8 GB → 3.8 GB  # untouched, because cargo-sweep can't
```

A full rebuild, for nothing. Clearing incremental first:

```
Incremental cache is 3906MB (limit 3072MB), clearing it
[INFO] Cleaned nothing from "/usr/src/app/target"
9.9G → 6.1G, deps intact at 5.7G
```

## Also

- **`[profile.dev] debug = 1` instead of `RUSTFLAGS` in the entrypoint.**
  `RUSTFLAGS` is part of a build's fingerprint, so exporting it from one
  entrypoint meant any cargo invoked another way built and kept a *second*
  complete set of artifacts. Two `libneems_api` rlibs at ~300 MB each is what
  that looked like. This also fixes the OOM-killed linker for one-off
  `docker compose run … cargo test`, which previously missed the cap.
- **The test-database leak.** `fast_test_rocket()` copies the golden database
  per test and nothing owned the copy. Only files untouched for an hour are
  removed — deleting one out from under a parallel test binary would be worse
  than leaving a stray. Superseded golden databases go the same way.
- **`./bin/dosh disk` and `./bin/dosh sweep`**, so this is inspectable and
  fixable by hand instead of only on a timer inside one container.
  `dosh depends` now installs cargo-sweep.

## Reference numbers

One clean build of everything — every bin and every test binary, single
fingerprint, no incremental — measures **5.7 GB**. That's the floor; the 10 GB
default leaves room for it plus churn. Setting the ceiling below a full build
would just sweep away artifacts that are immediately rebuilt.

The largest remaining lever on the floor itself is that each of the ~20
integration test binaries statically links the whole workspace at ~245 MB
(8.0 GB across 68 executables). Consolidating them would cut that
substantially — worth its own issue if the floor matters.

## Testing

- Planted a 3.5 GB fake incremental cache and a stray test DB, then ran the
  entrypoint's own `sweep_target`: incremental cleared, cargo-sweep correctly
  found nothing further to do, deps untouched, stray removed.
- Verified the pre-fix failure mode (deps nuked to 648 KB) to confirm the
  ordering is what prevents it.
- `dosh disk` exits 0 both with and without stray databases (it runs under
  `set -eo pipefail`, where an unmatched glob would otherwise abort it).
- Planted backdated and fresh test DBs, ran a real test binary: stale removed,
  fresh left alone, tests green.
- `cargo test --features test-staging -p neems-api -p neems-data` green apart
  from the two pre-existing `collectors.rs` ping failures (`CAP_NET_RAW`).
- `cargo fmt --check`, `bin/dosh lint-clippy`, `bash -n` on both scripts clean.

## Needs

- `docker compose build neems-api` to pick up `cargo-sweep`. Until then the
  entrypoint skips the sweep rather than failing.
- A companion `devenv` change setting `CARGO_TARGET_MAXSIZE`,
  `CARGO_TARGET_SWEEP_INTERVAL` and `CARGO_INCREMENTAL_MAXSIZE_MB` on the
  `neems-api` service. I've made that edit locally but left it uncommitted,
  since `devenv` has unrelated in-flight work in the same file.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
